### PR TITLE
Migrate to wallet-based auth, add init/whoami/daemon, CI

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+echo "  cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "  cargo build (lints enforced via Cargo.toml)"
+cargo build --all-targets
+
+echo "  cargo test"
+cargo test --all --quiet
+
+echo "All checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  build:
+    name: Build and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all-targets
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all
+
+  security:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.claude/
 /AGENTS.md
 docs/plans/*
+.env*
+*.pid
+*.sock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,7 @@ dependencies = [
  "base64",
  "clap",
  "hex",
+ "libc",
  "predicates",
  "serde_json",
  "tempfile",
@@ -1932,6 +1933,8 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "turnkey_api_key_stamper"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621735f1649d8b25ea40394525fb3eefa41911550dbccb64f5d75dfe1abdeecf"
 dependencies = [
  "base64",
  "hex",
@@ -1964,6 +1967,8 @@ dependencies = [
 [[package]]
 name = "turnkey_client"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f216ea270ec4a37daa491679b716962cda7819cac982b49088979b2edf6067df"
 dependencies = [
  "mime",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ assert_cmd = { version = "2", default-features = false }
 base64 = { version = "0.22.0", default-features = false, features = ["std"] }
 clap = { version = "4.5", features = ["std", "derive", "help", "usage", "error-context", "env"], default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
+libc = { version = "0.2", default-features = false }
 predicates = { version = "3", default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
@@ -19,6 +20,26 @@ sha2 = { version = "0.10", default-features = false }
 tempfile = { version = "3.19.1", default-features = false }
 tokio = { version = "=1.47.1", default-features = false }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
-turnkey_api_key_stamper = { path = "/Users/zeke/tkhq/code/rust-sdk/api_key_stamper", version = "0.6.0" }
-turnkey_client = { path = "/Users/zeke/tkhq/code/rust-sdk/client", version = "0.6.0" }
+turnkey_api_key_stamper = { version = "0.6.0", default-features = false }
+turnkey_client = { version = "0.6.0", default-features = false }
 wiremock = { version = "0.6", default-features = false }
+
+[workspace.lints.rust]
+dead_code = "warn"
+unused_imports = "deny"
+unused_variables = "warn"
+unused_must_use = "deny"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# Allow these pedantic lints that conflict with project style.
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+return_self_not_must_use = "allow"
+struct_excessive_bools = "allow"
+wildcard_imports = "allow"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # `tk`
 
-Experimental Turnkey auth workspace centered on the `tk` CLI.
+Turnkey auth CLI for SSH and Git workflows backed by Turnkey wallets.
 
-`tk` is focused on general agent authorization, attribution, and credential management with Turnkey backed keys.
-
-- Git SSH signing with a Turnkey private key
-- An SSH agent that signs SSH requests with a Turnkey private key
+- Git SSH signing with a Turnkey wallet key
+- SSH agent that signs requests with a Turnkey wallet key
+- Interactive setup with automatic wallet creation
 
 > Warning: `tk` is experimental and has not been audited.
 
@@ -19,61 +18,92 @@ Experimental Turnkey auth workspace centered on the `tk` CLI.
 From the root of this repo:
 
 ```bash
-cargo install -p tk
+cargo install --path tk
 ```
 
 The installed binary is named `tk`.
 
-## Commands
+## Quick start
 
 ```bash
-tk config
+export TURNKEY_API_PRIVATE_KEY="<hex-private-key>"
+tk init \
+  --organization-id <org-id> \
+  --api-public-key <hex-public-key>
+
+tk whoami
 tk public-key
-tk git-sign
-tk ssh-agent
 ```
+
+`tk init` validates your credentials, finds (or creates) a wallet with an Ed25519 account, and saves everything to `~/.config/turnkey/tk.toml`.
+
+## Commands
+
+```
+tk init          Initialize credentials and wallet setup
+tk whoami        Display authenticated identity
+tk config        Inspect and update configuration
+tk public-key    Print the SSH public key
+tk git-sign      Git SSH signer interface
+tk ssh-agent     Manage the SSH agent daemon
+```
+
+### SSH agent
+
+```bash
+tk ssh-agent start              # start background daemon
+tk ssh-agent status             # check if running, print SSH_AUTH_SOCK
+tk ssh-agent stop               # stop the daemon
+tk ssh-agent --socket <path>    # run in foreground (advanced)
+```
+
+Use `eval $(tk ssh-agent status)` to set `SSH_AUTH_SOCK` in your shell.
 
 ## Configuration
 
 `tk` resolves configuration in this order:
 
 1. Environment variables
-2. Global config file
-3. Built in defaults
-
-The default global config file path is:
-
-```bash
-~/.config/turnkey/tk.toml
-```
+2. Global config file (`~/.config/turnkey/tk.toml`)
+3. Built-in defaults
 
 Set `TURNKEY_TK_CONFIG_PATH` to override the config file location.
-
-You can inspect or update config with:
 
 ```bash
 tk config list
 tk config get turnkey.organizationId
-tk config set turnkey.organizationId "<org-id>"
-tk config set turnkey.apiPublicKey "<api-public-key>"
-tk config set turnkey.apiPrivateKey "<api-private-key>"
-tk config set turnkey.privateKeyId "<ed25519-private-key-id>"
 tk config set turnkey.apiBaseUrl "https://api.turnkey.com"
 ```
 
-`tk config list` prints the fully resolved effective configuration, so environment-variable overrides appear in its output. Secret values such as `turnkey.apiPrivateKey` are redacted in both `config list` and `config get`.
+Secret values such as `turnkey.apiPrivateKey` are redacted in `config list` and `config get`. The `signingAddress` and `signingPublicKey` fields are set automatically by `tk init`.
 
-### Environment Overrides
+### Environment variables
 
 ```bash
 export TURNKEY_ORGANIZATION_ID="<org-id>"
 export TURNKEY_API_PUBLIC_KEY="<api-public-key>"
 export TURNKEY_API_PRIVATE_KEY="<api-private-key>"
-export TURNKEY_PRIVATE_KEY_ID="<ed25519-private-key-id>"
-export TURNKEY_API_BASE_URL="https://api.turnkey.com" # optional
+export TURNKEY_API_BASE_URL="https://api.turnkey.com"  # optional
 ```
 
-These environment variables override values stored in the global config file. This can be helpful for CI.
+These override values stored in the config file. Useful for CI.
+
+## Development
+
+### Pre-commit hooks
+
+```bash
+git config core.hooksPath .github/hooks
+```
+
+### CI
+
+The GitHub Actions workflow runs on every push and PR to main:
+
+- `cargo fmt --check`
+- `cargo build` (lint rules enforced via `[workspace.lints]` in Cargo.toml)
+- `cargo test`
+- Security audit via `cargo-audit`
 
 ## Guides
 

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.0.0-alpha.0"
 edition.workspace = true
 license.workspace = true
 description = "Turnkey backed auth library for SSH, Git signing, and related workflows"
-repository = "https://github.com/tkhq/rust-sdk"
+repository = "https://github.com/tkhq/tk"
 homepage = "https://turnkey.com"
 
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+tempfile = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -18,6 +19,9 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "proce
 toml = { workspace = true }
 turnkey_api_key_stamper = { workspace = true }
 turnkey_client = { workspace = true }
+
+[lints]
+workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/auth/src/config.rs
+++ b/auth/src/config.rs
@@ -10,7 +10,6 @@ const CONFIG_PATH_ENV: &str = "TURNKEY_TK_CONFIG_PATH";
 const ORGANIZATION_ID_ENV: &str = "TURNKEY_ORGANIZATION_ID";
 const API_PUBLIC_KEY_ENV: &str = "TURNKEY_API_PUBLIC_KEY";
 const API_PRIVATE_KEY_ENV: &str = "TURNKEY_API_PRIVATE_KEY";
-const PRIVATE_KEY_ID_ENV: &str = "TURNKEY_PRIVATE_KEY_ID";
 const API_BASE_URL_ENV: &str = "TURNKEY_API_BASE_URL";
 const REDACTED_VALUE: &str = "<redacted>";
 
@@ -23,8 +22,10 @@ pub struct Config {
     pub api_public_key: String,
     /// Turnkey API private key used for request stamping.
     pub api_private_key: String,
-    /// Turnkey Ed25519 private key identifier.
-    pub private_key_id: String,
+    /// Wallet account address used as the `signWith` parameter for signing.
+    pub signing_address: String,
+    /// Hex-encoded Ed25519 public key for SSH operations.
+    pub signing_public_key: String,
     /// Base URL for the Turnkey API.
     pub api_base_url: String,
 }
@@ -38,8 +39,10 @@ pub struct ResolvedConfig {
     pub api_public_key: Option<String>,
     /// Resolved Turnkey API private key, if present.
     pub api_private_key: Option<String>,
-    /// Resolved Turnkey private key identifier, if present.
-    pub private_key_id: Option<String>,
+    /// Resolved wallet account signing address, if present.
+    pub signing_address: Option<String>,
+    /// Resolved hex-encoded Ed25519 public key, if present.
+    pub signing_public_key: Option<String>,
     /// Resolved API base URL, including defaulting.
     pub api_base_url: String,
 }
@@ -53,8 +56,10 @@ pub enum ConfigKey {
     ApiPublicKey,
     /// `turnkey.apiPrivateKey`
     ApiPrivateKey,
-    /// `turnkey.privateKeyId`
-    PrivateKeyId,
+    /// `turnkey.signingAddress`
+    SigningAddress,
+    /// `turnkey.signingPublicKey`
+    SigningPublicKey,
     /// `turnkey.apiBaseUrl`
     ApiBaseUrl,
 }
@@ -100,11 +105,8 @@ impl ResolvedConfig {
                 API_PRIVATE_KEY_ENV,
                 persisted.turnkey.api_private_key.as_deref(),
             ),
-            private_key_id: resolve_value(
-                env,
-                PRIVATE_KEY_ID_ENV,
-                persisted.turnkey.private_key_id.as_deref(),
-            ),
+            signing_address: persisted.turnkey.signing_address.clone(),
+            signing_public_key: persisted.turnkey.signing_public_key.clone(),
             api_base_url: resolve_value(
                 env,
                 API_BASE_URL_ENV,
@@ -136,11 +138,8 @@ impl ResolvedConfig {
                 API_PRIVATE_KEY_ENV,
                 persisted.turnkey.api_private_key.as_deref(),
             ),
-            private_key_id: resolve_value(
-                env,
-                PRIVATE_KEY_ID_ENV,
-                persisted.turnkey.private_key_id.as_deref(),
-            ),
+            signing_address: persisted.turnkey.signing_address.clone(),
+            signing_public_key: persisted.turnkey.signing_public_key.clone(),
             api_base_url: resolve_value(
                 env,
                 API_BASE_URL_ENV,
@@ -156,7 +155,8 @@ impl ResolvedConfig {
             ConfigKey::OrganizationId => self.organization_id.as_deref(),
             ConfigKey::ApiPublicKey => self.api_public_key.as_deref(),
             ConfigKey::ApiPrivateKey => self.api_private_key.as_deref(),
-            ConfigKey::PrivateKeyId => self.private_key_id.as_deref(),
+            ConfigKey::SigningAddress => self.signing_address.as_deref(),
+            ConfigKey::SigningPublicKey => self.signing_public_key.as_deref(),
             ConfigKey::ApiBaseUrl => Some(&self.api_base_url),
         }
     }
@@ -168,7 +168,8 @@ impl ResolvedConfig {
                 organization_id: self.organization_id.clone().unwrap_or_default(),
                 api_public_key: self.api_public_key.clone().unwrap_or_default(),
                 api_private_key: redact_if_present(self.api_private_key.as_deref()),
-                private_key_id: self.private_key_id.clone().unwrap_or_default(),
+                signing_address: self.signing_address.clone().unwrap_or_default(),
+                signing_public_key: self.signing_public_key.clone().unwrap_or_default(),
                 api_base_url: self.api_base_url.clone(),
             },
         })
@@ -180,7 +181,11 @@ impl ResolvedConfig {
             organization_id: required_value("turnkey.organizationId", self.organization_id)?,
             api_public_key: required_value("turnkey.apiPublicKey", self.api_public_key)?,
             api_private_key: required_value("turnkey.apiPrivateKey", self.api_private_key)?,
-            private_key_id: required_value("turnkey.privateKeyId", self.private_key_id)?,
+            signing_address: required_value("turnkey.signingAddress", self.signing_address)?,
+            signing_public_key: required_value(
+                "turnkey.signingPublicKey",
+                self.signing_public_key,
+            )?,
             api_base_url: self.api_base_url,
         })
     }
@@ -193,7 +198,8 @@ impl ConfigKey {
             "turnkey.organizationId" => Ok(Self::OrganizationId),
             "turnkey.apiPublicKey" => Ok(Self::ApiPublicKey),
             "turnkey.apiPrivateKey" => Ok(Self::ApiPrivateKey),
-            "turnkey.privateKeyId" => Ok(Self::PrivateKeyId),
+            "turnkey.signingAddress" => Ok(Self::SigningAddress),
+            "turnkey.signingPublicKey" => Ok(Self::SigningPublicKey),
             "turnkey.apiBaseUrl" => Ok(Self::ApiBaseUrl),
             _ => Err(anyhow!("unsupported config key: {value}")),
         }
@@ -212,6 +218,32 @@ pub fn global_config_path() -> Result<PathBuf> {
         .join(".config")
         .join("turnkey")
         .join("tk.toml"))
+}
+
+/// Atomically writes a full set of init configuration values to the config file.
+///
+/// This replaces any existing config file contents. Prefer this over multiple
+/// `set_config_value` calls to avoid partial writes on interruption.
+pub async fn save_init_config(
+    organization_id: &str,
+    api_public_key: &str,
+    api_private_key: &str,
+    signing_address: &str,
+    signing_public_key: &str,
+    api_base_url: Option<&str>,
+) -> Result<()> {
+    let path = global_config_path()?;
+    let config = PersistedConfigFile {
+        turnkey: PersistedTurnkeyConfig {
+            organization_id: Some(organization_id.to_string()),
+            api_public_key: Some(api_public_key.to_string()),
+            api_private_key: Some(api_private_key.to_string()),
+            signing_address: Some(signing_address.to_string()),
+            signing_public_key: Some(signing_public_key.to_string()),
+            api_base_url: api_base_url.map(std::string::ToString::to_string),
+        },
+    };
+    save_persisted_config(&path, &config).await
 }
 
 /// Returns one resolved config value, redacting the private key when requested.
@@ -266,7 +298,22 @@ async fn save_persisted_config(path: &Path, config: &PersistedConfigFile) -> Res
         tokio::fs::create_dir_all(parent).await?;
     }
     let serialized = toml::to_string_pretty(config).context("failed to serialize config file")?;
-    tokio::fs::write(path, serialized).await?;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("config path has no parent directory"))?;
+    let tmp = tempfile::NamedTempFile::new_in(parent)
+        .context("failed to create temporary config file")?;
+    std::fs::write(tmp.path(), &serialized).context("failed to write temporary config file")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(tmp.path(), perms)?;
+    }
+
+    tmp.persist(path).context("failed to persist config file")?;
     Ok(())
 }
 
@@ -324,7 +371,9 @@ struct PersistedTurnkeyConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     api_private_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    private_key_id: Option<String>,
+    signing_address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    signing_public_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     api_base_url: Option<String>,
 }
@@ -335,7 +384,8 @@ impl PersistedTurnkeyConfig {
             ConfigKey::OrganizationId => self.organization_id = Some(value),
             ConfigKey::ApiPublicKey => self.api_public_key = Some(value),
             ConfigKey::ApiPrivateKey => self.api_private_key = Some(value),
-            ConfigKey::PrivateKeyId => self.private_key_id = Some(value),
+            ConfigKey::SigningAddress => self.signing_address = Some(value),
+            ConfigKey::SigningPublicKey => self.signing_public_key = Some(value),
             ConfigKey::ApiBaseUrl => self.api_base_url = Some(value),
         }
     }
@@ -352,6 +402,7 @@ struct DisplayTurnkeyConfig {
     organization_id: String,
     api_public_key: String,
     api_private_key: String,
-    private_key_id: String,
+    signing_address: String,
+    signing_public_key: String,
     api_base_url: String,
 }

--- a/auth/src/git_sign.rs
+++ b/auth/src/git_sign.rs
@@ -11,7 +11,7 @@ pub async fn run_git_sign(ssh_keygen_args: &[String]) -> anyhow::Result<()> {
     let payload = tokio::fs::read(&invocation.payload_path).await?;
     let public_key = tokio::fs::read_to_string(&invocation.public_key_path).await?;
     let parsed_public_key = ssh::parse_public_key_line(&public_key)?;
-    let configured_public_key = signer.get_public_key().await?;
+    let configured_public_key = signer.get_public_key()?;
     if parsed_public_key.public_key != configured_public_key {
         return Err(anyhow!(
             "requested SSH public key does not match the configured Turnkey key"

--- a/auth/src/init.rs
+++ b/auth/src/init.rs
@@ -1,0 +1,142 @@
+use anyhow::{Context, Result, anyhow};
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::immutable::common::v1::{AddressFormat, Curve, PathFormat};
+use turnkey_client::generated::{
+    CreateWalletIntent, GetWalletAccountsRequest, GetWalletsRequest, WalletAccountParams,
+};
+use turnkey_client::{TurnkeyClient, TurnkeyClientError};
+
+use crate::config;
+
+/// Result of the init process.
+pub struct InitResult {
+    /// The wallet account signing address.
+    pub signing_address: String,
+    /// The hex-encoded Ed25519 public key.
+    pub signing_public_key: String,
+    /// The organization identifier used.
+    pub organization_id: String,
+    /// Whether a new wallet was created.
+    pub created: bool,
+}
+
+/// Runs the interactive initialization flow.
+///
+/// Validates the provided credentials, searches existing wallets for one
+/// with an Ed25519 account, creates a new wallet if none found,
+/// and persists the resolved signing address and public key to the config.
+pub async fn run_init(
+    organization_id: &str,
+    api_public_key: &str,
+    api_private_key: &str,
+    api_base_url: Option<&str>,
+) -> Result<InitResult> {
+    let base_url = api_base_url.unwrap_or("https://api.turnkey.com");
+
+    let api_key = TurnkeyP256ApiKey::from_strings(api_private_key, Some(api_public_key))
+        .context("invalid API key pair")?;
+
+    let client = TurnkeyClient::builder()
+        .api_key(api_key)
+        .base_url(base_url)
+        .build()
+        .context("failed to build Turnkey client")?;
+
+    // Search existing wallets for one with an Ed25519 account.
+    let wallets = client
+        .get_wallets(GetWalletsRequest {
+            organization_id: organization_id.to_string(),
+        })
+        .await
+        .map_err(|e: TurnkeyClientError| anyhow!("failed to list wallets: {e}"))?;
+
+    let mut found_account: Option<(String, String)> = None; // (address, public_key)
+
+    for wallet in &wallets.wallets {
+        let accounts = client
+            .get_wallet_accounts(GetWalletAccountsRequest {
+                organization_id: organization_id.to_string(),
+                wallet_id: Some(wallet.wallet_id.clone()),
+                include_wallet_details: None,
+                pagination_options: None,
+            })
+            .await
+            .map_err(|e: TurnkeyClientError| anyhow!("failed to list wallet accounts: {e}"))?;
+
+        if let Some(account) = accounts.accounts.iter().find(|a| a.curve == Curve::Ed25519) {
+            let pk = account
+                .public_key
+                .as_ref()
+                .ok_or_else(|| anyhow!("Ed25519 wallet account missing public key"))?;
+            found_account = Some((account.address.clone(), pk.clone()));
+            break;
+        }
+    }
+
+    let (signing_address, signing_public_key, created) = match found_account {
+        Some((addr, pk)) => (addr, pk, false),
+        None => {
+            let result = client
+                .create_wallet(
+                    organization_id.to_string(),
+                    client.current_timestamp(),
+                    CreateWalletIntent {
+                        wallet_name: "tk-default".to_string(),
+                        accounts: vec![WalletAccountParams {
+                            curve: Curve::Ed25519,
+                            path_format: PathFormat::Bip32,
+                            path: "m/44'/501'/0'/0'".to_string(),
+                            address_format: AddressFormat::Compressed,
+                        }],
+                        mnemonic_length: None,
+                    },
+                )
+                .await
+                .map_err(|e: TurnkeyClientError| anyhow!("failed to create wallet: {e}"))?;
+
+            // Fetch the newly created account to get its public key and address.
+            let wallet_id = &result.result.wallet_id;
+            let accounts = client
+                .get_wallet_accounts(GetWalletAccountsRequest {
+                    organization_id: organization_id.to_string(),
+                    wallet_id: Some(wallet_id.clone()),
+                    include_wallet_details: None,
+                    pagination_options: None,
+                })
+                .await
+                .map_err(|e: TurnkeyClientError| {
+                    anyhow!("failed to list new wallet accounts: {e}")
+                })?;
+
+            let account = accounts
+                .accounts
+                .iter()
+                .find(|a| a.curve == Curve::Ed25519)
+                .ok_or_else(|| anyhow!("newly created wallet has no Ed25519 account"))?;
+
+            let pk = account
+                .public_key
+                .as_ref()
+                .ok_or_else(|| anyhow!("newly created Ed25519 account missing public key"))?;
+
+            (account.address.clone(), pk.clone(), true)
+        }
+    };
+
+    config::save_init_config(
+        organization_id,
+        api_public_key,
+        api_private_key,
+        &signing_address,
+        &signing_public_key,
+        api_base_url,
+    )
+    .await?;
+
+    Ok(InitResult {
+        signing_address,
+        signing_public_key,
+        organization_id: organization_id.to_string(),
+        created,
+    })
+}

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -5,9 +5,13 @@
 pub mod config;
 /// Git SSH signing helpers backed by Turnkey.
 pub mod git_sign;
+/// Interactive initialization and wallet setup.
+pub mod init;
 /// Public-key helpers backed by Turnkey.
 pub mod public_key;
 /// SSH wire-format helpers for public keys and signatures.
 pub mod ssh;
 /// Turnkey-backed signing client helpers.
 pub mod turnkey;
+/// Identity verification (whoami) helpers.
+pub mod whoami;

--- a/auth/src/public_key.rs
+++ b/auth/src/public_key.rs
@@ -2,9 +2,9 @@ use crate::config::Config;
 use crate::ssh::encode_public_key_line;
 use crate::turnkey::TurnkeySigner;
 
-/// Fetches the configured Turnkey public key and renders it in OpenSSH format.
+/// Returns the configured Turnkey public key rendered in OpenSSH format.
 pub async fn get_public_key_line() -> anyhow::Result<String> {
     let signer = TurnkeySigner::new(Config::resolve().await?)?;
-    let public_key = signer.get_public_key().await?;
+    let public_key = signer.get_public_key()?;
     encode_public_key_line(&public_key, None)
 }

--- a/auth/src/ssh/agent.rs
+++ b/auth/src/ssh/agent.rs
@@ -20,7 +20,7 @@ pub async fn run(socket: PathBuf) -> anyhow::Result<()> {
 
     let result = async {
         let signer = Arc::new(TurnkeySigner::new(Config::resolve().await?)?);
-        let public_key = signer.get_public_key().await?;
+        let public_key = signer.get_public_key()?;
         let public_key_blob = Arc::new(
             ssh::parse_public_key_line(&ssh::encode_public_key_line(&public_key, None)?)
                 .context("failed to build SSH public key blob")?
@@ -68,10 +68,10 @@ pub async fn run(socket: PathBuf) -> anyhow::Result<()> {
 
         connections.abort_all();
         while let Some(join_result) = connections.join_next().await {
-            if let Err(error) = join_result {
-                if error.is_panic() {
-                    return Err(anyhow!("ssh-agent connection task panicked: {error}"));
-                }
+            if let Err(error) = join_result
+                && error.is_panic()
+            {
+                return Err(anyhow!("ssh-agent connection task panicked: {error}"));
             }
         }
 
@@ -111,7 +111,7 @@ async fn handle_connection(
             Some(protocol::SSH_AGENTC_SIGN_REQUEST) => {
                 match protocol::parse_sign_request_frame(&frame) {
                     Ok(request) if request.public_key_blob == *configured_public_key_blob => {
-                        match signer.sign_ssh_auth_payload(&request.data).await {
+                        match signer.sign_ed25519(&request.data).await {
                             Ok(signature) => protocol::encode_sign_response(&signature)
                                 .unwrap_or_else(|_| {
                                     protocol::encode_agent_frame(protocol::SSH_AGENT_FAILURE, &[])

--- a/auth/src/ssh/git.rs
+++ b/auth/src/ssh/git.rs
@@ -33,7 +33,7 @@ impl GitSignInvocation {
                     namespace = Some(
                         iter.next()
                             .ok_or_else(|| anyhow!("missing value after -n"))?
-                            .to_string(),
+                            .clone(),
                     );
                 }
                 "-f" => {

--- a/auth/src/ssh/mod.rs
+++ b/auth/src/ssh/mod.rs
@@ -11,7 +11,10 @@ pub mod protocol;
 /// Git signing invocation parsing.
 pub mod git;
 
-const SSH_ED25519_ALGORITHM: &str = "ssh-ed25519";
+/// Shared SSH wire-format encoding and decoding primitives.
+pub(crate) mod wire;
+
+use wire::SSH_ED25519_ALGORITHM;
 const SSHSIG_PREAMBLE: &[u8] = b"SSHSIG";
 /// Default hash algorithm name encoded into SSHSIG payloads.
 pub const DEFAULT_HASH_ALGORITHM: &str = "sha512";
@@ -37,11 +40,7 @@ pub fn encode_public_key_line(public_key: &[u8], comment: Option<&str>) -> Resul
     })
 }
 
-fn encode_string(bytes: &[u8], mut output: Vec<u8>) -> Vec<u8> {
-    output.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
-    output.extend_from_slice(bytes);
-    output
-}
+use wire::encode_string;
 
 /// Parsed components of an OpenSSH Ed25519 public key line.
 pub struct ParsedPublicKey {
@@ -160,20 +159,4 @@ fn parse_public_key_blob(blob: &[u8]) -> Result<(String, Vec<u8>)> {
     Ok((algorithm, key))
 }
 
-fn read_ssh_bytes(cursor: &mut &[u8]) -> Result<Vec<u8>> {
-    if cursor.len() < 4 {
-        return Err(anyhow!("truncated SSH string length"));
-    }
-
-    let length = u32::from_be_bytes(cursor[..4].try_into().expect("length slice should be 4"));
-    *cursor = &cursor[4..];
-
-    let length = length as usize;
-    if cursor.len() < length {
-        return Err(anyhow!("truncated SSH string body"));
-    }
-
-    let value = cursor[..length].to_vec();
-    *cursor = &cursor[length..];
-    Ok(value)
-}
+use wire::read_ssh_bytes;

--- a/auth/src/ssh/protocol.rs
+++ b/auth/src/ssh/protocol.rs
@@ -9,8 +9,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::time::{Duration, timeout};
 
-const SSH_ED25519_ALGORITHM: &str = "ssh-ed25519";
-const CONNECTION_IO_TIMEOUT: Duration = Duration::from_millis(250);
+use super::wire::SSH_ED25519_ALGORITHM;
+const CONNECTION_IO_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_AGENT_FRAME_SIZE: usize = 1 << 20;
 
 /// Generic SSH agent failure response message code.
@@ -138,11 +138,7 @@ async fn read_exact_with_deadline(stream: &mut UnixStream, buf: &mut [u8]) -> st
     }
 }
 
-fn encode_string(bytes: &[u8], mut output: Vec<u8>) -> Vec<u8> {
-    output.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
-    output.extend_from_slice(bytes);
-    output
-}
+use super::wire::encode_string;
 
 fn parse_agent_frame(frame: &[u8]) -> Result<(u8, &[u8])> {
     if frame.len() < 4 {
@@ -164,23 +160,7 @@ fn parse_agent_frame(frame: &[u8]) -> Result<(u8, &[u8])> {
     Ok((frame[4], &frame[5..]))
 }
 
-fn read_ssh_bytes(cursor: &mut &[u8]) -> Result<Vec<u8>> {
-    if cursor.len() < 4 {
-        return Err(anyhow!("truncated SSH string length"));
-    }
-
-    let length = u32::from_be_bytes(cursor[..4].try_into().expect("length slice should be 4"));
-    *cursor = &cursor[4..];
-
-    let length = length as usize;
-    if cursor.len() < length {
-        return Err(anyhow!("truncated SSH string body"));
-    }
-
-    let value = cursor[..length].to_vec();
-    *cursor = &cursor[length..];
-    Ok(value)
-}
+use super::wire::read_ssh_bytes;
 
 fn read_u32(cursor: &mut &[u8]) -> Result<u32> {
     if cursor.len() < 4 {

--- a/auth/src/ssh/wire.rs
+++ b/auth/src/ssh/wire.rs
@@ -1,0 +1,31 @@
+use anyhow::{Result, anyhow};
+
+/// SSH algorithm identifier for Ed25519 keys.
+pub const SSH_ED25519_ALGORITHM: &str = "ssh-ed25519";
+
+/// Appends an SSH string (4-byte big-endian length prefix + data) to the output buffer.
+pub fn encode_string(bytes: &[u8], mut output: Vec<u8>) -> Vec<u8> {
+    output.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    output.extend_from_slice(bytes);
+    output
+}
+
+/// Reads one SSH string (4-byte big-endian length prefix + data) from the cursor,
+/// advancing it past the consumed bytes.
+pub fn read_ssh_bytes(cursor: &mut &[u8]) -> Result<Vec<u8>> {
+    if cursor.len() < 4 {
+        return Err(anyhow!("truncated SSH string length"));
+    }
+
+    let length = u32::from_be_bytes(cursor[..4].try_into().expect("length slice should be 4"));
+    *cursor = &cursor[4..];
+
+    let length = length as usize;
+    if cursor.len() < length {
+        return Err(anyhow!("truncated SSH string body"));
+    }
+
+    let value = cursor[..length].to_vec();
+    *cursor = &cursor[length..];
+    Ok(value)
+}

--- a/auth/src/turnkey.rs
+++ b/auth/src/turnkey.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result, anyhow};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::SignRawPayloadIntentV2;
 use turnkey_client::generated::immutable::common::v1::HashFunction;
 use turnkey_client::generated::immutable::common::v1::PayloadEncoding;
-use turnkey_client::generated::{GetPrivateKeyRequest, SignRawPayloadIntentV2};
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
 
 use crate::config::Config;
@@ -29,42 +29,20 @@ impl TurnkeySigner {
         Ok(Self { client, config })
     }
 
-    /// Fetches the configured Ed25519 public key bytes from Turnkey.
-    pub async fn get_public_key(&self) -> Result<Vec<u8>> {
-        let response = self
-            .client
-            .get_private_key(GetPrivateKeyRequest {
-                organization_id: self.config.organization_id.clone(),
-                private_key_id: self.config.private_key_id.clone(),
-            })
-            .await
-            .map_err(map_turnkey_error)?;
-
-        let private_key = response
-            .private_key
-            .ok_or_else(|| anyhow!("Turnkey did not return a private key object"))?;
-
-        decode_public_key(&private_key.public_key)
+    /// Returns the configured Ed25519 public key bytes.
+    pub fn get_public_key(&self) -> Result<Vec<u8>> {
+        decode_public_key(&self.config.signing_public_key)
     }
 
     /// Signs a raw Ed25519 payload through Turnkey and returns the 64-byte signature.
     pub async fn sign_ed25519(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.sign_raw_ed25519_payload(payload).await
-    }
-
-    /// Signs a raw SSH authentication payload through Turnkey and returns the 64-byte signature.
-    pub async fn sign_ssh_auth_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.sign_raw_ed25519_payload(payload).await
-    }
-
-    async fn sign_raw_ed25519_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
         let response = self
             .client
             .sign_raw_payload(
                 self.config.organization_id.clone(),
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
-                    sign_with: self.config.private_key_id.clone(),
+                    sign_with: self.config.signing_address.clone(),
                     payload: hex::encode(payload),
                     encoding: PayloadEncoding::Hexadecimal,
                     hash_function: HashFunction::NotApplicable,
@@ -77,11 +55,12 @@ impl TurnkeySigner {
     }
 }
 
+#[allow(clippy::needless_pass_by_value)] // map_err passes by value
 fn map_turnkey_error(error: TurnkeyClientError) -> anyhow::Error {
     anyhow!("Turnkey API request failed: {error}")
 }
 
-fn decode_public_key(encoded: &str) -> Result<Vec<u8>> {
+pub(crate) fn decode_public_key(encoded: &str) -> Result<Vec<u8>> {
     let trimmed = encoded.trim().trim_start_matches("0x");
     hex::decode(trimmed).map_err(|_| anyhow!("expected hex-encoded Turnkey public key"))
 }
@@ -142,7 +121,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decode_signature_parts_signs_raw_ssh_auth_payload() {
+    async fn sign_ed25519_returns_64_byte_signature() {
         let server = MockServer::start().await;
         let payload = b"ssh-agent-challenge";
         let signature = [0x55; 64];
@@ -178,15 +157,16 @@ mod tests {
             organization_id: "org-id".to_string(),
             api_public_key: hex::encode(api_key.compressed_public_key()),
             api_private_key: hex::encode(api_key.private_key()),
-            private_key_id: "pk-id".to_string(),
+            signing_address: "test-address".to_string(),
+            signing_public_key: "55".repeat(32),
             api_base_url: server.uri(),
         })
         .expect("signer should build");
 
         let result = signer
-            .sign_ssh_auth_payload(payload)
+            .sign_ed25519(payload)
             .await
-            .expect("ssh auth payload should sign");
+            .expect("payload should sign");
 
         let requests = server
             .received_requests()
@@ -198,16 +178,8 @@ mod tests {
             .expect("request body should be valid JSON");
         assert_eq!(body["type"], "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2");
         assert_eq!(body["organizationId"], "org-id");
-        assert_eq!(body["parameters"]["signWith"], "pk-id");
+        assert_eq!(body["parameters"]["signWith"], "test-address");
         assert_eq!(body["parameters"]["payload"], hex::encode(payload));
-        assert_eq!(
-            body["parameters"]["encoding"],
-            "PAYLOAD_ENCODING_HEXADECIMAL"
-        );
-        assert_eq!(
-            body["parameters"]["hashFunction"],
-            "HASH_FUNCTION_NOT_APPLICABLE"
-        );
         assert_eq!(result, signature.to_vec());
     }
 }

--- a/auth/src/whoami.rs
+++ b/auth/src/whoami.rs
@@ -1,0 +1,45 @@
+use anyhow::{Context, Result, anyhow};
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::GetWhoamiRequest;
+use turnkey_client::{TurnkeyClient, TurnkeyClientError};
+
+use crate::config::Config;
+
+/// Authenticated identity information returned by the Turnkey API.
+pub struct Identity {
+    /// Turnkey organization identifier.
+    pub organization_id: String,
+    /// Turnkey organization name.
+    pub organization_name: String,
+    /// Authenticated user identifier.
+    pub user_id: String,
+    /// Authenticated username.
+    pub username: String,
+}
+
+/// Fetches the authenticated identity for the current configuration.
+pub async fn get_identity(config: &Config) -> Result<Identity> {
+    let api_key =
+        TurnkeyP256ApiKey::from_strings(&config.api_private_key, Some(&config.api_public_key))
+            .map_err(|e| anyhow!("failed to load Turnkey API key: {e}"))?;
+
+    let client = TurnkeyClient::builder()
+        .api_key(api_key)
+        .base_url(&config.api_base_url)
+        .build()
+        .context("failed to build Turnkey client")?;
+
+    let response = client
+        .get_whoami(GetWhoamiRequest {
+            organization_id: config.organization_id.clone(),
+        })
+        .await
+        .map_err(|e: TurnkeyClientError| anyhow!("Turnkey API request failed: {e}"))?;
+
+    Ok(Identity {
+        organization_id: response.organization_id,
+        organization_name: response.organization_name,
+        user_id: response.user_id,
+        username: response.username,
+    })
+}

--- a/auth/tests/config_resolution.rs
+++ b/auth/tests/config_resolution.rs
@@ -14,7 +14,8 @@ fn config_resolution_prefers_env_over_global_over_default() {
 organizationId = "file-org"
 apiPublicKey = "file-pub"
 apiPrivateKey = "file-priv"
-privateKeyId = "file-key"
+signingAddress = "file-addr"
+signingPublicKey = "file-spk"
 "#,
     )
     .expect("config file should be written");
@@ -26,7 +27,6 @@ privateKeyId = "file-key"
             "TURNKEY_API_PRIVATE_KEY".to_string(),
             "env-priv".to_string(),
         ),
-        ("TURNKEY_PRIVATE_KEY_ID".to_string(), "env-key".to_string()),
     ]);
 
     let config = Config::resolve_from_map(&config_path, &env).expect("config should resolve");
@@ -34,6 +34,8 @@ privateKeyId = "file-key"
     assert_eq!(config.organization_id, "env-org");
     assert_eq!(config.api_public_key, "env-pub");
     assert_eq!(config.api_private_key, "env-priv");
-    assert_eq!(config.private_key_id, "env-key");
+    // signing_address and signing_public_key come from config file only (no env override).
+    assert_eq!(config.signing_address, "file-addr");
+    assert_eq!(config.signing_public_key, "file-spk");
     assert_eq!(config.api_base_url, "https://api.turnkey.com");
 }

--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -1,8 +1,8 @@
 # Git signing
 
-Use `tk` as Git's SSH signing program after configuring your Turnkey credentials.
+Use `tk` as Git's SSH signing program to sign commits and tags with your Turnkey wallet key.
 
-Ensure you have followed the [configuration section of the repository readme](../README.md#configuration).
+Ensure you have run `tk init` first (see the [quick start](../README.md#quick-start)).
 
 ```bash
 git config --global gpg.format ssh
@@ -12,4 +12,4 @@ printf '%s %s\n' "you@example.com" "$(tk public-key)" >> ~/.config/git/allowed_s
 git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
 ```
 
-After this setup, Git can use `tk git-sign` through the configured SSH signing program when creating signed commits or tags. It is invoked with `tk -Y` since that is how Git expects to invoke the given ssh program.
+After this setup, Git invokes `tk -Y sign` when creating signed commits or tags.

--- a/docs/ssh-agent.md
+++ b/docs/ssh-agent.md
@@ -1,24 +1,37 @@
 # SSH agent
 
-Run `tk` as a foreground SSH agent when you want plain `ssh` to authenticate with your Turnkey Ed25519 key.
+Run `tk` as an SSH agent to authenticate with your Turnkey Ed25519 wallet key.
 
-Ensure you have followed the [configuration section of the repository readme](../README.md#configuration).
+Ensure you have run `tk init` first (see the [quick start](../README.md#quick-start)).
 
-Use two terminals:
-
-Terminal 1:
+## Daemon mode (recommended)
 
 ```bash
-tk ssh-agent --socket /tmp/auth.sock
-```
-
-Terminal 2:
-
-```bash
-export SSH_AUTH_SOCK=/tmp/auth.sock
+tk ssh-agent start
+eval $(tk ssh-agent status)
 
 ssh-add -L
 ssh user@host
 ```
 
-`ssh-add -L` should print the Turnkey-backed OpenSSH public key while `ssh user@host` uses the agent socket for signing.
+To stop the agent:
+
+```bash
+tk ssh-agent stop
+```
+
+## Foreground mode
+
+For debugging or custom socket paths:
+
+```bash
+tk ssh-agent --socket /tmp/auth.sock
+```
+
+In another terminal:
+
+```bash
+export SSH_AUTH_SOCK=/tmp/auth.sock
+ssh-add -L
+ssh user@host
+```

--- a/tk/Cargo.toml
+++ b/tk/Cargo.toml
@@ -8,8 +8,12 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+libc = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs", "time", "process"] }
 turnkey_auth = { path = "../auth" }
+
+[lints]
+workspace = true
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/tk/src/cli.rs
+++ b/tk/src/cli.rs
@@ -6,20 +6,25 @@ Environment:
   TURNKEY_ORGANIZATION_ID
   TURNKEY_API_PUBLIC_KEY
   TURNKEY_API_PRIVATE_KEY
-  TURNKEY_PRIVATE_KEY_ID
   TURNKEY_API_BASE_URL
 
 Config file:
   Set TURNKEY_TK_CONFIG_PATH to override the config file location.
   Otherwise tk uses ~/.config/turnkey/tk.toml.
 
+Quick start:
+  TURNKEY_API_PRIVATE_KEY=<priv> tk init --organization-id <org> --api-public-key <pub>
+  tk whoami
+  tk public-key
+
 SSH agent:
-  tk ssh-agent --socket /tmp/auth.sock
-  export SSH_AUTH_SOCK=/tmp/auth.sock
+  tk ssh-agent start
+  eval $(tk ssh-agent status)
 ";
 
 #[derive(Debug, Parser)]
 #[command(
+    version,
     about = "CLI for Turnkey backed auth workflows",
     long_about = None,
     after_help = AFTER_HELP
@@ -36,6 +41,8 @@ impl Cli {
         let args = Self::parse();
 
         match args.command {
+            Commands::Init(args) => commands::init::run(args).await,
+            Commands::Whoami(args) => commands::whoami::run(args).await,
             Commands::Config(args) => commands::config::run(args).await,
             Commands::SshAgent(args) => commands::agent::run(args).await,
             Commands::GitSign(args) => commands::git_sign::run(args).await,
@@ -46,9 +53,13 @@ impl Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Initialize tk with Turnkey credentials and wallet setup.
+    Init(commands::init::Args),
+    /// Display the authenticated Turnkey identity.
+    Whoami(commands::whoami::Args),
     /// Inspect and update persistent auth configuration.
     Config(commands::config::Args),
-    /// Run a foreground SSH agent over a Unix socket.
+    /// Manage the Turnkey SSH agent.
     SshAgent(commands::agent::Args),
     /// Sign a payload using the Git SSH signer interface.
     GitSign(commands::git_sign::Args),

--- a/tk/src/commands/agent.rs
+++ b/tk/src/commands/agent.rs
@@ -1,16 +1,221 @@
 use std::path::PathBuf;
 
-use clap::Args as ClapArgs;
+use clap::{Args as ClapArgs, Subcommand};
+
+const DEFAULT_SOCKET_DIR: &str = "/tmp";
 
 #[derive(Debug, ClapArgs)]
-#[command(about = "Run a foreground SSH agent over a Unix socket.", long_about = None)]
+#[command(about = "Manage the Turnkey SSH agent.", long_about = None)]
 pub struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// Unix socket path to bind for SSH agent connections.
-    #[arg(long, value_name = "path")]
-    pub socket: PathBuf,
+    /// Used only when running without a subcommand (foreground mode).
+    #[arg(long, value_name = "path", global = true)]
+    pub socket: Option<PathBuf>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Start the SSH agent as a background daemon.
+    Start,
+    /// Stop a running SSH agent daemon.
+    Stop,
+    /// Check if the SSH agent daemon is running.
+    Status,
 }
 
 /// Runs the `tk ssh-agent` subcommand.
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    turnkey_auth::ssh::agent::run(args.socket).await
+    match args.command {
+        None => {
+            let socket = args.socket.ok_or_else(|| {
+                anyhow::anyhow!("--socket is required when running in foreground mode")
+            })?;
+            turnkey_auth::ssh::agent::run(socket).await
+        }
+        Some(Command::Start) => {
+            let socket = resolve_socket_path(args.socket.as_ref());
+            let pid_path = pid_file_path();
+
+            if let Some(pid) = read_running_pid(&pid_path) {
+                println!("SSH agent already running (pid {pid})");
+                print_env(&socket);
+                return Ok(());
+            }
+
+            let exe = std::env::current_exe()?;
+            let mut cmd = tokio::process::Command::new(exe);
+            cmd.arg("ssh-agent")
+                .arg("--socket")
+                .arg(&socket)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+
+            // SAFETY: setsid() is async-signal-safe and is the standard way to
+            // detach a daemon from the controlling terminal after fork, before exec.
+            unsafe {
+                cmd.pre_exec(|| {
+                    if libc::setsid() == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+
+            let child = cmd.spawn()?;
+            let pid = child
+                .id()
+                .ok_or_else(|| anyhow::anyhow!("failed to get daemon pid"))?;
+
+            if let Some(parent) = pid_path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+            tokio::fs::write(&pid_path, pid.to_string()).await?;
+
+            // Wait briefly for socket to appear.
+            for _ in 0..20 {
+                if tokio::fs::try_exists(&socket).await.unwrap_or(false) {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+
+            println!("SSH agent started (pid {pid})");
+            print_env(&socket);
+            Ok(())
+        }
+        Some(Command::Stop) => {
+            let pid_path = pid_file_path();
+            let socket = resolve_socket_path(args.socket.as_ref());
+
+            if let Some(pid) = read_running_pid(&pid_path) {
+                // Verify it is actually our agent by probing the socket.
+                if !probe_agent(&socket).await {
+                    anyhow::bail!(
+                        "pid {pid} is running but the socket is not responding as an SSH agent"
+                    );
+                }
+
+                let pid_t = libc::pid_t::try_from(pid)
+                    .map_err(|_| anyhow::anyhow!("pid {pid} exceeds valid range"))?;
+
+                // SAFETY: kill with SIGTERM requests graceful termination of a validated PID.
+                let rc = unsafe { libc::kill(pid_t, libc::SIGTERM) };
+                if rc == -1 {
+                    let err = std::io::Error::last_os_error();
+                    if err.raw_os_error() == Some(libc::EPERM) {
+                        anyhow::bail!(
+                            "permission denied sending signal to pid {pid} \
+                             (process may belong to another user)"
+                        );
+                    }
+                }
+                let _ = std::fs::remove_file(&pid_path);
+                let _ = std::fs::remove_file(&socket);
+
+                println!("SSH agent stopped (pid {pid})");
+                Ok(())
+            } else {
+                println!("SSH agent is not running");
+                Ok(())
+            }
+        }
+        Some(Command::Status) => {
+            let pid_path = pid_file_path();
+            if let Some(pid) = read_running_pid(&pid_path) {
+                let socket = resolve_socket_path(args.socket.as_ref());
+                println!("SSH agent is running (pid {pid})");
+                print_env(&socket);
+                Ok(())
+            } else {
+                println!("SSH agent is not running");
+                Ok(())
+            }
+        }
+    }
+}
+
+fn resolve_socket_path(explicit: Option<&PathBuf>) -> PathBuf {
+    explicit.cloned().unwrap_or_else(|| {
+        // SAFETY: getuid() is always safe and has no failure mode.
+        let uid = unsafe { libc::getuid() };
+        PathBuf::from(DEFAULT_SOCKET_DIR).join(format!("tk-agent-{uid}.sock"))
+    })
+}
+
+fn pid_file_path() -> PathBuf {
+    // SAFETY: getuid() is always safe and has no failure mode.
+    let uid = unsafe { libc::getuid() };
+    PathBuf::from(DEFAULT_SOCKET_DIR).join(format!("tk-agent-{uid}.pid"))
+}
+
+fn read_running_pid(path: &std::path::Path) -> Option<u32> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let pid: u32 = content.trim().parse().ok()?;
+
+    let pid_t = libc::pid_t::try_from(pid).ok()?;
+    // SAFETY: kill with signal 0 performs a permission check without sending a signal.
+    let rc = unsafe { libc::kill(pid_t, 0) };
+    if rc == 0 {
+        return Some(pid);
+    }
+
+    // EPERM means the process exists but belongs to another user. Treat it as alive
+    // to avoid removing a PID file for a process we cannot manage.
+    let errno = std::io::Error::last_os_error();
+    if errno.raw_os_error() == Some(libc::EPERM) {
+        return Some(pid);
+    }
+
+    // Process does not exist, clean up stale PID file.
+    let _ = std::fs::remove_file(path);
+    None
+}
+
+/// Probes the socket with an SSH agent request-identities message to verify
+/// it is actually our agent before sending SIGTERM.
+async fn probe_agent(socket: &std::path::Path) -> bool {
+    tokio::time::timeout(std::time::Duration::from_secs(5), probe_agent_inner(socket))
+        .await
+        .unwrap_or(false)
+}
+
+async fn probe_agent_inner(socket: &std::path::Path) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+
+    let Ok(mut stream) = UnixStream::connect(socket).await else {
+        return false;
+    };
+
+    // SSH_AGENTC_REQUEST_IDENTITIES = 11, frame: [0,0,0,1,11]
+    let request = [0u8, 0, 0, 1, 11];
+    if stream.write_all(&request).await.is_err() {
+        return false;
+    }
+
+    let mut len_buf = [0u8; 4];
+    if stream.read_exact(&mut len_buf).await.is_err() {
+        return false;
+    }
+
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len == 0 || len > 1 << 20 {
+        return false;
+    }
+
+    let mut body = vec![0u8; len];
+    if stream.read_exact(&mut body).await.is_err() {
+        return false;
+    }
+
+    // SSH_AGENT_IDENTITIES_ANSWER = 12
+    body[0] == 12
+}
+
+fn print_env(socket: &std::path::Path) {
+    println!("SSH_AUTH_SOCK={}; export SSH_AUTH_SOCK;", socket.display());
 }

--- a/tk/src/commands/config.rs
+++ b/tk/src/commands/config.rs
@@ -39,6 +39,12 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         }
         Command::Set(args) => {
             let key = ConfigKey::parse(&args.key)?;
+            if key == ConfigKey::ApiPrivateKey {
+                anyhow::bail!(
+                    "cannot set turnkey.apiPrivateKey via the command line.\n\
+                     Use the TURNKEY_API_PRIVATE_KEY environment variable or `tk init` instead."
+                );
+            }
             config::set_config_value(key, &args.value).await?;
         }
         Command::List => {

--- a/tk/src/commands/init.rs
+++ b/tk/src/commands/init.rs
@@ -1,0 +1,65 @@
+use clap::Args as ClapArgs;
+use turnkey_auth::config;
+
+#[derive(Debug, ClapArgs)]
+#[command(
+    about = "Initialize tk with Turnkey credentials and wallet setup.",
+    long_about = None,
+    after_help = "The API private key must be provided via the TURNKEY_API_PRIVATE_KEY \
+                  environment variable (not as a CLI flag) to prevent secrets from \
+                  appearing in process listings."
+)]
+pub struct Args {
+    /// Turnkey organization identifier.
+    #[arg(long, env = "TURNKEY_ORGANIZATION_ID")]
+    pub organization_id: String,
+
+    /// Turnkey API public key (hex-encoded P256 compressed public key).
+    #[arg(long, env = "TURNKEY_API_PUBLIC_KEY")]
+    pub api_public_key: String,
+
+    /// Turnkey API private key (hex-encoded P256 private key).
+    /// Accepted only via the `TURNKEY_API_PRIVATE_KEY` environment variable
+    /// to avoid leaking secrets in process listings.
+    #[arg(skip)]
+    pub api_private_key: Option<String>,
+
+    /// Turnkey API base URL override.
+    #[arg(long, env = "TURNKEY_API_BASE_URL")]
+    pub api_base_url: Option<String>,
+}
+
+/// Runs the `tk init` subcommand.
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    let api_private_key = args
+        .api_private_key
+        .or_else(|| std::env::var("TURNKEY_API_PRIVATE_KEY").ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "TURNKEY_API_PRIVATE_KEY environment variable is required.\n\
+                 Set it before running init to avoid exposing secrets in process listings."
+            )
+        })?;
+
+    println!("Validating credentials and checking for existing wallets...");
+
+    let result = turnkey_auth::init::run_init(
+        &args.organization_id,
+        &args.api_public_key,
+        &api_private_key,
+        args.api_base_url.as_deref(),
+    )
+    .await?;
+
+    if result.created {
+        println!("Created new wallet with Ed25519 account");
+    } else {
+        println!("Found existing Ed25519 account");
+    }
+    println!("Signing address: {}", result.signing_address);
+
+    let config_path = config::global_config_path()?;
+    println!("Configuration saved to {}", config_path.display());
+    println!("\nRun `tk whoami` to verify your setup.");
+    Ok(())
+}

--- a/tk/src/commands/mod.rs
+++ b/tk/src/commands/mod.rs
@@ -1,8 +1,12 @@
-/// Foreground SSH agent command.
+/// SSH agent command with start/stop/status subcommands.
 pub mod agent;
 /// Persistent configuration inspection and mutation commands.
 pub mod config;
 /// Git SSH signing command implementation.
 pub mod git_sign;
+/// Interactive initialization command.
+pub mod init;
 /// Public key printing command implementation.
 pub mod public_key;
+/// Identity verification command.
+pub mod whoami;

--- a/tk/src/commands/whoami.rs
+++ b/tk/src/commands/whoami.rs
@@ -1,0 +1,25 @@
+use clap::Args as ClapArgs;
+use turnkey_auth::config::Config;
+
+#[derive(Debug, ClapArgs)]
+#[command(about = "Display the authenticated Turnkey identity.", long_about = None)]
+pub struct Args {}
+
+/// Runs the `tk whoami` subcommand.
+pub async fn run(_args: Args) -> anyhow::Result<()> {
+    let config = Config::resolve()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}\n\nRun `tk init` to set up your credentials."))?;
+
+    let identity = turnkey_auth::whoami::get_identity(&config).await?;
+
+    println!(
+        "Organization:  {} ({})",
+        identity.organization_name, identity.organization_id
+    );
+    println!(
+        "User:          {} ({})",
+        identity.username, identity.user_id
+    );
+    Ok(())
+}

--- a/tk/tests/agent_command.rs
+++ b/tk/tests/agent_command.rs
@@ -28,11 +28,11 @@ async fn ssh_agent_lists_identity_and_signs_for_configured_key() {
     let public_key_blob = public_key_blob(&TURNKEY_TEST_PUBLIC_KEY);
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(TURNKEY_TEST_PUBLIC_KEY)).await;
     mount_sign_raw_payload_mock(&server, &TURNKEY_TEST_SIGNATURE).await;
 
     let api_key = TurnkeyP256ApiKey::generate();
-    let mut child = spawn_tk_ssh_agent(&socket_path, &server, &api_key);
+    let config_path = write_test_config(temp.path(), &api_key, &server);
+    let mut child = spawn_tk_ssh_agent(&socket_path, &config_path);
     wait_for_socket(&socket_path, &mut child).await;
 
     let identities = exchange_frame(
@@ -59,8 +59,8 @@ async fn ssh_agent_lists_identity_and_signs_for_configured_key() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(requests.len(), 2);
-    let sign_request_body: serde_json::Value = requests[1]
+    assert_eq!(requests.len(), 1);
+    let sign_request_body: serde_json::Value = requests[0]
         .body_json()
         .expect("sign request body should be valid JSON");
     assert_eq!(
@@ -84,10 +84,10 @@ async fn ssh_agent_rejects_other_keys_and_unsupported_messages() {
     let other_public_key_blob = public_key_blob(&[0x11; 32]);
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(TURNKEY_TEST_PUBLIC_KEY)).await;
 
     let api_key = TurnkeyP256ApiKey::generate();
-    let mut child = spawn_tk_ssh_agent(&socket_path, &server, &api_key);
+    let config_path = write_test_config(temp.path(), &api_key, &server);
+    let mut child = spawn_tk_ssh_agent(&socket_path, &config_path);
     wait_for_socket(&socket_path, &mut child).await;
 
     let sign_failure = exchange_frame(
@@ -110,7 +110,7 @@ async fn ssh_agent_rejects_other_keys_and_unsupported_messages() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 0);
 }
 
 #[tokio::test]
@@ -120,10 +120,10 @@ async fn ssh_agent_contains_malformed_clients_and_keeps_serving() {
     let public_key_blob = public_key_blob(&TURNKEY_TEST_PUBLIC_KEY);
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(TURNKEY_TEST_PUBLIC_KEY)).await;
 
     let api_key = TurnkeyP256ApiKey::generate();
-    let mut child = spawn_tk_ssh_agent(&socket_path, &server, &api_key);
+    let config_path = write_test_config(temp.path(), &api_key, &server);
+    let mut child = spawn_tk_ssh_agent(&socket_path, &config_path);
     wait_for_socket(&socket_path, &mut child).await;
 
     send_partial_frame_then_disconnect(&socket_path).await;
@@ -146,7 +146,7 @@ async fn ssh_agent_contains_malformed_clients_and_keeps_serving() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 0);
 }
 
 #[tokio::test]
@@ -156,10 +156,10 @@ async fn ssh_agent_rejects_oversized_frames_and_keeps_serving() {
     let public_key_blob = public_key_blob(&TURNKEY_TEST_PUBLIC_KEY);
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(TURNKEY_TEST_PUBLIC_KEY)).await;
 
     let api_key = TurnkeyP256ApiKey::generate();
-    let mut child = spawn_tk_ssh_agent(&socket_path, &server, &api_key);
+    let config_path = write_test_config(temp.path(), &api_key, &server);
+    let mut child = spawn_tk_ssh_agent(&socket_path, &config_path);
     wait_for_socket(&socket_path, &mut child).await;
 
     let oversized_socket_path = socket_path.clone();
@@ -193,7 +193,7 @@ async fn ssh_agent_rejects_oversized_frames_and_keeps_serving() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 0);
 
     oversized_client
         .await
@@ -207,10 +207,10 @@ async fn ssh_agent_times_out_stalled_clients_and_keeps_serving() {
     let public_key_blob = public_key_blob(&TURNKEY_TEST_PUBLIC_KEY);
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(TURNKEY_TEST_PUBLIC_KEY)).await;
 
     let api_key = TurnkeyP256ApiKey::generate();
-    let mut child = spawn_tk_ssh_agent(&socket_path, &server, &api_key);
+    let config_path = write_test_config(temp.path(), &api_key, &server);
+    let mut child = spawn_tk_ssh_agent(&socket_path, &config_path);
     wait_for_socket(&socket_path, &mut child).await;
 
     let stalled_socket_path = socket_path.clone();
@@ -244,7 +244,7 @@ async fn ssh_agent_times_out_stalled_clients_and_keeps_serving() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 0);
 
     stalled_client
         .await
@@ -257,10 +257,10 @@ async fn ssh_agent_exits_on_sigterm_and_removes_socket() {
     let socket_path = temp.path().join("auth.sock");
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(TURNKEY_TEST_PUBLIC_KEY)).await;
 
     let api_key = TurnkeyP256ApiKey::generate();
-    let mut child = spawn_tk_ssh_agent(&socket_path, &server, &api_key);
+    let config_path = write_test_config(temp.path(), &api_key, &server);
+    let mut child = spawn_tk_ssh_agent(&socket_path, &config_path);
     wait_for_socket(&socket_path, &mut child).await;
 
     let status = Command::new("kill")
@@ -302,26 +302,35 @@ fn encode_ssh_string(bytes: &[u8], output: &mut Vec<u8>) {
     output.extend_from_slice(bytes);
 }
 
-fn spawn_tk_ssh_agent(
-    socket_path: &Path,
-    server: &MockServer,
-    api_key: &TurnkeyP256ApiKey,
-) -> ChildGuard {
+fn write_test_config(dir: &Path, api_key: &TurnkeyP256ApiKey, server: &MockServer) -> PathBuf {
+    let config_path = dir.join("tk.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[turnkey]
+organizationId = "org-id"
+apiPublicKey = "{}"
+apiPrivateKey = "{}"
+signingAddress = "test-address"
+signingPublicKey = "{}"
+apiBaseUrl = "{}"
+"#,
+            hex::encode(api_key.compressed_public_key()),
+            hex::encode(api_key.private_key()),
+            hex::encode(TURNKEY_TEST_PUBLIC_KEY),
+            server.uri(),
+        ),
+    )
+    .expect("config file should be written");
+    config_path
+}
+
+fn spawn_tk_ssh_agent(socket_path: &Path, config_path: &Path) -> ChildGuard {
     let child = Command::new(env!("CARGO_BIN_EXE_tk"))
         .arg("ssh-agent")
         .arg("--socket")
         .arg(socket_path)
-        .env("TURNKEY_ORGANIZATION_ID", "org-id")
-        .env(
-            "TURNKEY_API_PUBLIC_KEY",
-            hex::encode(api_key.compressed_public_key()),
-        )
-        .env(
-            "TURNKEY_API_PRIVATE_KEY",
-            hex::encode(api_key.private_key()),
-        )
-        .env("TURNKEY_PRIVATE_KEY_ID", "pk-id")
-        .env("TURNKEY_API_BASE_URL", server.uri())
+        .env("TURNKEY_TK_CONFIG_PATH", config_path)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -400,28 +409,6 @@ async fn send_partial_frame_then_disconnect(socket_path: &Path) {
         .write_all(&[0, 0, 0, 8, protocol::SSH_AGENTC_SIGN_REQUEST, 0, 0])
         .await
         .expect("partial frame should write");
-}
-
-async fn mount_get_private_key_mock(server: &MockServer, public_key: &str) {
-    Mock::given(method("POST"))
-        .and(path("/public/v1/query/get_private_key"))
-        .and(header_exists("X-Stamp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "privateKey": {
-                "privateKeyId": "pk-id",
-                "publicKey": public_key,
-                "privateKeyName": "ssh agent signer",
-                "curve": "CURVE_ED25519",
-                "addresses": [],
-                "privateKeyTags": [],
-                "createdAt": null,
-                "updatedAt": null,
-                "exported": false,
-                "imported": false
-            }
-        })))
-        .mount(server)
-        .await;
 }
 
 async fn mount_sign_raw_payload_mock(server: &MockServer, signature: &[u8]) {

--- a/tk/tests/cli.rs
+++ b/tk/tests/cli.rs
@@ -9,6 +9,8 @@ fn cli_help_lists_commands() {
 
     cmd.assert()
         .success()
+        .stdout(predicate::str::contains("init"))
+        .stdout(predicate::str::contains("whoami"))
         .stdout(predicate::str::contains("config"))
         .stdout(predicate::str::contains("git-sign"))
         .stdout(predicate::str::contains("ssh-agent"))
@@ -16,16 +18,13 @@ fn cli_help_lists_commands() {
         .stdout(predicate::str::contains("TURNKEY_ORGANIZATION_ID"))
         .stdout(predicate::str::contains("TURNKEY_API_PUBLIC_KEY"))
         .stdout(predicate::str::contains("TURNKEY_API_PRIVATE_KEY"))
-        .stdout(predicate::str::contains("TURNKEY_PRIVATE_KEY_ID"))
         .stdout(predicate::str::contains("TURNKEY_API_BASE_URL"))
         .stdout(predicate::str::contains("TURNKEY_TK_CONFIG_PATH"))
         .stdout(predicate::str::contains("~/.config/turnkey/tk.toml"))
         .stdout(predicate::str::contains(
-            "ssh-agent   Run a foreground SSH agent over a Unix socket",
+            "ssh-agent   Manage the Turnkey SSH agent",
         ))
-        .stdout(predicate::str::contains(
-            "export SSH_AUTH_SOCK=/tmp/auth.sock",
-        ));
+        .stdout(predicate::str::contains("tk ssh-agent start"));
 
     let mut agent_cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
     agent_cmd.arg("ssh-agent").arg("--help");
@@ -33,7 +32,10 @@ fn cli_help_lists_commands() {
     agent_cmd
         .assert()
         .success()
-        .stdout(predicate::str::contains("--socket"));
+        .stdout(predicate::str::contains("--socket"))
+        .stdout(predicate::str::contains("start"))
+        .stdout(predicate::str::contains("stop"))
+        .stdout(predicate::str::contains("status"));
 }
 
 #[test]
@@ -47,7 +49,6 @@ fn public_key_requires_turnkey_org_id() {
         .env_remove("TURNKEY_ORGANIZATION_ID")
         .env_remove("TURNKEY_API_PUBLIC_KEY")
         .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
         .env_remove("TURNKEY_API_BASE_URL");
 
     cmd.assert()

--- a/tk/tests/config_command.rs
+++ b/tk/tests/config_command.rs
@@ -29,7 +29,6 @@ fn config_round_trip() {
         .env_remove("TURNKEY_ORGANIZATION_ID")
         .env_remove("TURNKEY_API_PUBLIC_KEY")
         .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
         .env_remove("TURNKEY_API_BASE_URL");
     set_cmd.assert().success();
 
@@ -43,7 +42,6 @@ fn config_round_trip() {
         .env_remove("TURNKEY_ORGANIZATION_ID")
         .env_remove("TURNKEY_API_PUBLIC_KEY")
         .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
         .env_remove("TURNKEY_API_BASE_URL");
     get_cmd
         .assert()
@@ -57,7 +55,6 @@ fn config_round_trip() {
         .env("TURNKEY_ORGANIZATION_ID", "env-org")
         .env_remove("TURNKEY_API_PUBLIC_KEY")
         .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
         .env_remove("TURNKEY_API_BASE_URL");
     let output = list_cmd.assert().success().get_output().stdout.clone();
     let value: Value = serde_json::from_slice(&output).expect("config list should output json");
@@ -69,21 +66,12 @@ fn config_list_and_get_redact_private_key() {
     let temp = tempdir().expect("temp dir should exist");
     let config_path = temp.path().join("tk.toml");
 
-    let mut set_cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
-    set_cmd
-        .args([
-            "config",
-            "set",
-            "turnkey.apiPrivateKey",
-            "persisted-private-key",
-        ])
-        .env("TURNKEY_TK_CONFIG_PATH", &config_path)
-        .env_remove("TURNKEY_ORGANIZATION_ID")
-        .env_remove("TURNKEY_API_PUBLIC_KEY")
-        .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
-        .env_remove("TURNKEY_API_BASE_URL");
-    set_cmd.assert().success();
+    // Write the config file directly since `config set` blocks apiPrivateKey.
+    fs::write(
+        &config_path,
+        "[turnkey]\napiPrivateKey = \"persisted-private-key\"\n",
+    )
+    .expect("config file should be written");
 
     let mut list_cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
     list_cmd
@@ -92,7 +80,6 @@ fn config_list_and_get_redact_private_key() {
         .env_remove("TURNKEY_ORGANIZATION_ID")
         .env_remove("TURNKEY_API_PUBLIC_KEY")
         .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
         .env_remove("TURNKEY_API_BASE_URL");
     let output = list_cmd.assert().success().get_output().stdout.clone();
     let value: Value = serde_json::from_slice(&output).expect("config list should output json");
@@ -106,11 +93,33 @@ fn config_list_and_get_redact_private_key() {
         .env_remove("TURNKEY_ORGANIZATION_ID")
         .env_remove("TURNKEY_API_PUBLIC_KEY")
         .env_remove("TURNKEY_API_PRIVATE_KEY")
-        .env_remove("TURNKEY_PRIVATE_KEY_ID")
         .env_remove("TURNKEY_API_BASE_URL");
     get_cmd
         .assert()
         .success()
         .stdout(predicate::str::contains("<redacted>"))
         .stdout(predicate::str::contains("persisted-private-key").not());
+}
+
+#[test]
+fn config_set_rejects_api_private_key() {
+    let temp = tempdir().expect("temp dir should exist");
+    let config_path = temp.path().join("tk.toml");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.args([
+        "config",
+        "set",
+        "turnkey.apiPrivateKey",
+        "should-not-be-stored",
+    ])
+    .env("TURNKEY_TK_CONFIG_PATH", &config_path)
+    .env_remove("TURNKEY_ORGANIZATION_ID")
+    .env_remove("TURNKEY_API_PUBLIC_KEY")
+    .env_remove("TURNKEY_API_PRIVATE_KEY")
+    .env_remove("TURNKEY_API_BASE_URL");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot set turnkey.apiPrivateKey"));
 }

--- a/tk/tests/git_sign.rs
+++ b/tk/tests/git_sign.rs
@@ -40,7 +40,6 @@ async fn git_sign_writes_verifiable_sshsig_file() {
         ssh::parse_public_key_line(&public_key_line).expect("public key should parse");
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(&parsed_public_key.public_key)).await;
     Mock::given(method("POST"))
         .and(path("/public/v1/submit/sign_raw_payload"))
         .and(header_exists("X-Stamp"))
@@ -64,6 +63,26 @@ async fn git_sign_writes_verifiable_sshsig_file() {
         .await;
 
     let api_key = TurnkeyP256ApiKey::generate();
+    let config_path = temp.path().join("tk.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[turnkey]
+organizationId = "org-id"
+apiPublicKey = "{}"
+apiPrivateKey = "{}"
+signingAddress = "test-address"
+signingPublicKey = "{}"
+apiBaseUrl = "{}"
+"#,
+            hex::encode(api_key.compressed_public_key()),
+            hex::encode(api_key.private_key()),
+            hex::encode(&parsed_public_key.public_key),
+            server.uri(),
+        ),
+    )
+    .expect("config file should be written");
+
     let mut cmd = assert_cmd::Command::new(env!("CARGO_BIN_EXE_tk"));
     cmd.arg("git-sign")
         .arg("-Y")
@@ -73,17 +92,7 @@ async fn git_sign_writes_verifiable_sshsig_file() {
         .arg("-f")
         .arg(&public_key_path)
         .arg(&payload_path)
-        .env("TURNKEY_ORGANIZATION_ID", "org-id")
-        .env(
-            "TURNKEY_API_PUBLIC_KEY",
-            hex::encode(api_key.compressed_public_key()),
-        )
-        .env(
-            "TURNKEY_API_PRIVATE_KEY",
-            hex::encode(api_key.private_key()),
-        )
-        .env("TURNKEY_PRIVATE_KEY_ID", "pk-id")
-        .env("TURNKEY_API_BASE_URL", server.uri());
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path);
 
     cmd.assert().success();
 
@@ -153,7 +162,6 @@ async fn direct_ssh_signer_invocation_writes_verifiable_sshsig_file() {
         ssh::parse_public_key_line(&public_key_line).expect("public key should parse");
 
     let server = MockServer::start().await;
-    mount_get_private_key_mock(&server, &hex::encode(&parsed_public_key.public_key)).await;
     Mock::given(method("POST"))
         .and(path("/public/v1/submit/sign_raw_payload"))
         .and(header_exists("X-Stamp"))
@@ -177,6 +185,26 @@ async fn direct_ssh_signer_invocation_writes_verifiable_sshsig_file() {
         .await;
 
     let api_key = TurnkeyP256ApiKey::generate();
+    let config_path = temp.path().join("tk.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[turnkey]
+organizationId = "org-id"
+apiPublicKey = "{}"
+apiPrivateKey = "{}"
+signingAddress = "test-address"
+signingPublicKey = "{}"
+apiBaseUrl = "{}"
+"#,
+            hex::encode(api_key.compressed_public_key()),
+            hex::encode(api_key.private_key()),
+            hex::encode(&parsed_public_key.public_key),
+            server.uri(),
+        ),
+    )
+    .expect("config file should be written");
+
     let mut cmd = assert_cmd::Command::new(env!("CARGO_BIN_EXE_tk"));
     cmd.arg("-Y")
         .arg("sign")
@@ -185,17 +213,7 @@ async fn direct_ssh_signer_invocation_writes_verifiable_sshsig_file() {
         .arg("-f")
         .arg(&public_key_path)
         .arg(&payload_path)
-        .env("TURNKEY_ORGANIZATION_ID", "org-id")
-        .env(
-            "TURNKEY_API_PUBLIC_KEY",
-            hex::encode(api_key.compressed_public_key()),
-        )
-        .env(
-            "TURNKEY_API_PRIVATE_KEY",
-            hex::encode(api_key.private_key()),
-        )
-        .env("TURNKEY_PRIVATE_KEY_ID", "pk-id")
-        .env("TURNKEY_API_BASE_URL", server.uri());
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path);
 
     cmd.assert().success();
 
@@ -256,28 +274,26 @@ async fn git_sign_rejects_public_key_that_does_not_match_configured_turnkey_key(
         .await
         .expect("payload should be written");
 
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/public/v1/query/get_private_key"))
-        .and(header_exists("X-Stamp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "privateKey": {
-                "privateKeyId": "pk-id",
-                "publicKey": "1111111111111111111111111111111111111111111111111111111111111111",
-                "privateKeyName": "git signer",
-                "curve": "CURVE_ED25519",
-                "addresses": [],
-                "privateKeyTags": [],
-                "createdAt": null,
-                "updatedAt": null,
-                "exported": false,
-                "imported": false
-            }
-        })))
-        .mount(&server)
-        .await;
-
     let api_key = TurnkeyP256ApiKey::generate();
+    let config_path = temp.path().join("tk.toml");
+    // Use a different public key (all 0x11) than what ssh-keygen generated.
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[turnkey]
+organizationId = "org-id"
+apiPublicKey = "{}"
+apiPrivateKey = "{}"
+signingAddress = "test-address"
+signingPublicKey = "1111111111111111111111111111111111111111111111111111111111111111"
+apiBaseUrl = "https://localhost:1"
+"#,
+            hex::encode(api_key.compressed_public_key()),
+            hex::encode(api_key.private_key()),
+        ),
+    )
+    .expect("config file should be written");
+
     let mut cmd = assert_cmd::Command::new(env!("CARGO_BIN_EXE_tk"));
     cmd.arg("git-sign")
         .arg("-Y")
@@ -287,17 +303,7 @@ async fn git_sign_rejects_public_key_that_does_not_match_configured_turnkey_key(
         .arg("-f")
         .arg(&public_key_path)
         .arg(&payload_path)
-        .env("TURNKEY_ORGANIZATION_ID", "org-id")
-        .env(
-            "TURNKEY_API_PUBLIC_KEY",
-            hex::encode(api_key.compressed_public_key()),
-        )
-        .env(
-            "TURNKEY_API_PRIVATE_KEY",
-            hex::encode(api_key.private_key()),
-        )
-        .env("TURNKEY_PRIVATE_KEY_ID", "pk-id")
-        .env("TURNKEY_API_BASE_URL", server.uri());
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path);
 
     cmd.assert().failure().stderr(predicate::str::contains(
         "does not match the configured Turnkey key",
@@ -310,28 +316,6 @@ async fn git_sign_rejects_public_key_that_does_not_match_configured_turnkey_key(
             .expect("signature path should be readable"),
         "signature file should not be created"
     );
-}
-
-async fn mount_get_private_key_mock(server: &MockServer, public_key: &str) {
-    Mock::given(method("POST"))
-        .and(path("/public/v1/query/get_private_key"))
-        .and(header_exists("X-Stamp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "privateKey": {
-                "privateKeyId": "pk-id",
-                "publicKey": public_key,
-                "privateKeyName": "git signer",
-                "curve": "CURVE_ED25519",
-                "addresses": [],
-                "privateKeyTags": [],
-                "createdAt": null,
-                "updatedAt": null,
-                "exported": false,
-                "imported": false
-            }
-        })))
-        .mount(server)
-        .await;
 }
 
 async fn extract_raw_signature(

--- a/tk/tests/init_command.rs
+++ b/tk/tests/init_command.rs
@@ -1,0 +1,173 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{header_exists, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn api_key_env(cmd: &mut Command, api_key: &TurnkeyP256ApiKey) {
+    cmd.env(
+        "TURNKEY_API_PUBLIC_KEY",
+        hex::encode(api_key.compressed_public_key()),
+    )
+    .env(
+        "TURNKEY_API_PRIVATE_KEY",
+        hex::encode(api_key.private_key()),
+    );
+}
+
+#[tokio::test]
+async fn init_uses_existing_wallet_with_ed25519_account() {
+    let server = MockServer::start().await;
+
+    // Mock list wallets returning one wallet.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_wallets"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "wallets": [{
+                "walletId": "existing-wallet-id",
+                "walletName": "my-wallet",
+                "createdAt": null,
+                "updatedAt": null,
+                "exported": false,
+                "imported": false
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    // Mock list wallet accounts returning an Ed25519 account.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_wallet_accounts"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accounts": [{
+                "walletAccountId": "acct-id",
+                "organizationId": "org-id",
+                "walletId": "existing-wallet-id",
+                "curve": "CURVE_ED25519",
+                "pathFormat": "PATH_FORMAT_BIP32",
+                "path": "m/44'/501'/0'/0'",
+                "addressFormat": "ADDRESS_FORMAT_COMPRESSED",
+                "address": "test-address",
+                "publicKey": "aabbccdd",
+                "createdAt": null,
+                "updatedAt": null
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("tk.toml");
+
+    let api_key = TurnkeyP256ApiKey::generate();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("init")
+        .arg("--organization-id")
+        .arg("org-id")
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path)
+        .env("TURNKEY_API_BASE_URL", server.uri());
+    api_key_env(&mut cmd, &api_key);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Found existing Ed25519 account"))
+        .stdout(predicate::str::contains("Signing address: test-address"))
+        .stdout(predicate::str::contains("Configuration saved to"));
+
+    // Verify config was written with signing address and public key.
+    let contents = std::fs::read_to_string(&config_path).unwrap();
+    assert!(contents.contains("test-address"));
+    assert!(contents.contains("aabbccdd"));
+    assert!(contents.contains("org-id"));
+
+    // Verify permissions are 0600.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::metadata(&config_path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}
+
+#[tokio::test]
+async fn init_creates_wallet_when_none_exist() {
+    let server = MockServer::start().await;
+
+    // Mock list wallets returning empty.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_wallets"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "wallets": []
+        })))
+        .mount(&server)
+        .await;
+
+    // Mock create wallet.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/create_wallet"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "activity-id",
+                "organizationId": "org-id",
+                "fingerprint": "fingerprint",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_CREATE_WALLET",
+                "result": {
+                    "createWalletResult": {
+                        "walletId": "new-wallet-id",
+                        "addresses": ["new-address"]
+                    }
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    // Mock list wallet accounts for the newly created wallet.
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/list_wallet_accounts"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accounts": [{
+                "walletAccountId": "new-acct-id",
+                "organizationId": "org-id",
+                "walletId": "new-wallet-id",
+                "curve": "CURVE_ED25519",
+                "pathFormat": "PATH_FORMAT_BIP32",
+                "path": "m/44'/501'/0'/0'",
+                "addressFormat": "ADDRESS_FORMAT_COMPRESSED",
+                "address": "new-address",
+                "publicKey": "ddeeff00",
+                "createdAt": null,
+                "updatedAt": null
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("tk.toml");
+
+    let api_key = TurnkeyP256ApiKey::generate();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("init")
+        .arg("--organization-id")
+        .arg("org-id")
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path)
+        .env("TURNKEY_API_BASE_URL", server.uri());
+    api_key_env(&mut cmd, &api_key);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Created new wallet"))
+        .stdout(predicate::str::contains("Signing address: new-address"));
+
+    let contents = std::fs::read_to_string(&config_path).unwrap();
+    assert!(contents.contains("new-address"));
+    assert!(contents.contains("ddeeff00"));
+}

--- a/tk/tests/public_key_command.rs
+++ b/tk/tests/public_key_command.rs
@@ -1,46 +1,34 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-use wiremock::matchers::{header_exists, method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
 
-#[tokio::test]
-async fn public_key_prints_openssh_line_from_turnkey_key() {
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/public/v1/query/get_private_key"))
-        .and(header_exists("X-Stamp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "privateKey": {
-                "privateKeyId": "pk-id",
-                "publicKey": "6666666666666666666666666666666666666666666666666666666666666666",
-                "privateKeyName": "git signer",
-                "curve": "CURVE_ED25519",
-                "addresses": [],
-                "privateKeyTags": [],
-                "createdAt": null,
-                "updatedAt": null,
-                "exported": false,
-                "imported": false
-            }
-        })))
-        .mount(&server)
-        .await;
-
+#[test]
+fn public_key_prints_openssh_line_from_config() {
     let api_key = TurnkeyP256ApiKey::generate();
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("tk.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"[turnkey]
+organizationId = "org-id"
+apiPublicKey = "{}"
+apiPrivateKey = "{}"
+signingAddress = "test-address"
+signingPublicKey = "6666666666666666666666666666666666666666666666666666666666666666"
+apiBaseUrl = "https://localhost:1"
+"#,
+            hex::encode(api_key.compressed_public_key()),
+            hex::encode(api_key.private_key()),
+        ),
+    )
+    .unwrap();
+
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
     cmd.arg("public-key")
-        .env("TURNKEY_ORGANIZATION_ID", "org-id")
-        .env(
-            "TURNKEY_API_PUBLIC_KEY",
-            hex::encode(api_key.compressed_public_key()),
-        )
-        .env(
-            "TURNKEY_API_PRIVATE_KEY",
-            hex::encode(api_key.private_key()),
-        )
-        .env("TURNKEY_PRIVATE_KEY_ID", "pk-id")
-        .env("TURNKEY_API_BASE_URL", server.uri());
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path);
 
     cmd.assert().success().stdout(predicate::str::contains(
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZm",

--- a/tk/tests/whoami_command.rs
+++ b/tk/tests/whoami_command.rs
@@ -1,0 +1,75 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{header_exists, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn whoami_displays_identity() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/public/v1/query/whoami"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "organizationId": "org-123",
+            "organizationName": "Test Org",
+            "userId": "user-456",
+            "username": "testuser"
+        })))
+        .mount(&server)
+        .await;
+
+    let api_key = TurnkeyP256ApiKey::generate();
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("tk.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[turnkey]
+organizationId = "org-123"
+apiPublicKey = "{}"
+apiPrivateKey = "{}"
+signingAddress = "test-address"
+signingPublicKey = "6666666666666666666666666666666666666666666666666666666666666666"
+apiBaseUrl = "{}"
+"#,
+            hex::encode(api_key.compressed_public_key()),
+            hex::encode(api_key.private_key()),
+            server.uri(),
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("whoami")
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Organization:  Test Org (org-123)",
+        ))
+        .stdout(predicate::str::contains(
+            "User:          testuser (user-456)",
+        ));
+}
+
+#[tokio::test]
+async fn whoami_suggests_init_when_config_missing() {
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("tk.toml");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("whoami")
+        .env("TURNKEY_TK_CONFIG_PATH", &config_path)
+        .env_remove("TURNKEY_ORGANIZATION_ID")
+        .env_remove("TURNKEY_API_PUBLIC_KEY")
+        .env_remove("TURNKEY_API_PRIVATE_KEY")
+        .env_remove("TURNKEY_API_BASE_URL");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("tk init"));
+}


### PR DESCRIPTION
## Summary

- Replace private key auth with wallet-based signing. Config now stores `signingAddress` and `signingPublicKey` (resolved during `tk init`) instead of a wallet ID, eliminating runtime API calls for key lookup.
- Add `tk init` command that validates credentials, finds or creates an Ed25519 wallet account, and persists the resolved config.
- Add `tk whoami` to display authenticated identity from the Turnkey API.
- Add SSH agent daemon lifecycle: `tk ssh-agent start/stop/status` with PID management, socket probing, and `setsid` detach.
- Add `tk --version` flag.
- Security hardening: env-only API private key in init, atomic config writes with 0600 permissions, socket probe before SIGTERM, PID type safety.
- CI/CD: GitHub Actions (fmt, build with workspace lints, test, security audit) and pre-commit hooks.
- Deduplicated SSH wire helpers, workspace lint config, consolidated signing methods.
- Replaced hardcoded local path dependencies with crates.io versions.

## Test plan

- [ ] `cargo test --all` passes (30 tests across 13 suites)
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo build --all-targets` zero warnings
- [ ] Manual E2E against dev environment: init, whoami, public-key, config, git-sign, ssh-agent start/stop/status
- [ ] Config file permissions verified as 0600
- [ ] `tk init` without `TURNKEY_API_PRIVATE_KEY` fails with clear error
- [ ] `tk config set turnkey.apiPrivateKey` blocked with guidance message
- [ ] `tk whoami` without config suggests `tk init`