### PR TITLE
Add CI workflow, workspace lint config, and documentation

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+echo "  cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "  cargo build (lints enforced via Cargo.toml)"
+cargo build --all-targets
+
+echo "  cargo test"
+cargo test --all --quiet
+
+echo "All checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  build:
+    name: Build and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all-targets
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all
+
+  security:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.claude/
 /AGENTS.md
 docs/plans/*
+.env*
+*.pid
+*.sock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,23 @@ toml = { version = "0.8", default-features = false, features = ["parse", "displa
 turnkey_api_key_stamper = { git = "https://github.com/tkhq/rust-sdk.git", rev = "a64ca2b0d3178089221b648f3365eb67def95219" }
 turnkey_client = { git = "https://github.com/tkhq/rust-sdk.git", rev = "a64ca2b0d3178089221b648f3365eb67def95219" }
 wiremock = { version = "0.6", default-features = false }
+
+[workspace.lints.rust]
+dead_code = "warn"
+unused_imports = "deny"
+unused_variables = "warn"
+unused_must_use = "deny"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+return_self_not_must_use = "allow"
+struct_excessive_bools = "allow"
+wildcard_imports = "allow"
+needless_pass_by_value = "allow"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # `tk`
 
-Experimental Turnkey auth workspace centered on the `tk` CLI.
+Turnkey auth CLI for SSH and Git workflows backed by Turnkey wallets.
 
-`tk` is focused on general agent authorization, attribution, and credential management with Turnkey backed keys.
-
-- Git SSH signing with a Turnkey private key
-- An SSH agent that signs SSH requests with a Turnkey private key
+- Git SSH signing with a Turnkey wallet key
+- SSH agent that signs requests with a Turnkey wallet key
+- Interactive setup with automatic wallet creation
 
 > Warning: `tk` is experimental and has not been audited.
 
@@ -19,18 +18,42 @@ Experimental Turnkey auth workspace centered on the `tk` CLI.
 From the root of this repo:
 
 ```bash
-cargo install -p tk
+cargo install --path tk
 ```
 
 The installed binary is named `tk`.
 
-## Commands
+## Quick start
 
 ```bash
-tk config
+export TURNKEY_API_PRIVATE_KEY="<hex-private-key>"
+tk init \
+  --organization-id <org-id> \
+  --api-public-key <hex-public-key>
+
+tk whoami
 tk public-key
-tk git-sign
-tk ssh-agent
+```
+
+`tk init` validates your credentials, finds (or creates) a wallet with an Ed25519 account, and saves the signing config to the config file.
+
+## Commands
+
+```
+tk init          Initialize credentials and wallet setup
+tk whoami        Display authenticated identity
+tk config        Inspect and update configuration
+tk public-key    Print the SSH public key
+tk git-sign      Git SSH signer interface
+tk ssh-agent     Manage the SSH agent daemon
+```
+
+### SSH agent
+
+```bash
+tk ssh-agent start
+tk ssh-agent status
+tk ssh-agent stop
 ```
 
 ## Configuration
@@ -39,41 +62,45 @@ tk ssh-agent
 
 1. Environment variables
 2. Global config file
-3. Built in defaults
-
-The default global config file path is:
-
-```bash
-~/.config/turnkey/tk.toml
-```
+3. Built-in defaults
 
 Set `TURNKEY_TK_CONFIG_PATH` to override the config file location.
-
-You can inspect or update config with:
 
 ```bash
 tk config list
 tk config get turnkey.organizationId
-tk config set turnkey.organizationId "<org-id>"
-tk config set turnkey.apiPublicKey "<api-public-key>"
-tk config set turnkey.apiPrivateKey "<api-private-key>"
-tk config set turnkey.privateKeyId "<ed25519-private-key-id>"
 tk config set turnkey.apiBaseUrl "https://api.turnkey.com"
 ```
 
-`tk config list` prints the fully resolved effective configuration, so environment-variable overrides appear in its output. Secret values such as `turnkey.apiPrivateKey` are redacted in both `config list` and `config get`.
+Secret values such as `turnkey.apiPrivateKey` are redacted in `config list` and `config get`. The `signingAddress` and `signingPublicKey` fields are set automatically by `tk init`.
 
-### Environment Overrides
+### Environment variables
 
 ```bash
 export TURNKEY_ORGANIZATION_ID="<org-id>"
 export TURNKEY_API_PUBLIC_KEY="<api-public-key>"
 export TURNKEY_API_PRIVATE_KEY="<api-private-key>"
-export TURNKEY_PRIVATE_KEY_ID="<ed25519-private-key-id>"
-export TURNKEY_API_BASE_URL="https://api.turnkey.com" # optional
+export TURNKEY_API_BASE_URL="https://api.turnkey.com"  # optional
 ```
 
-These environment variables override values stored in the global config file. This can be helpful for CI.
+These override values stored in the config file. Useful for CI.
+
+## Development
+
+### Pre-commit hooks
+
+```bash
+git config core.hooksPath .github/hooks
+```
+
+### CI
+
+The GitHub Actions workflow runs on every push and PR to main:
+
+- `cargo fmt --check`
+- `cargo build` (lint rules enforced via `[workspace.lints]` in Cargo.toml)
+- `cargo test`
+- Security audit via `cargo-audit`
 
 ## Guides
 

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -20,5 +20,8 @@ toml = { workspace = true }
 turnkey_api_key_stamper = { workspace = true }
 turnkey_client = { workspace = true }
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 wiremock = { workspace = true }

--- a/auth/src/config.rs
+++ b/auth/src/config.rs
@@ -331,7 +331,7 @@ pub async fn save_init_config(
             api_private_key: Some(api_private_key.to_string()),
             signing_address: Some(signing_address.to_string()),
             signing_public_key: Some(signing_public_key.to_string()),
-            api_base_url: api_base_url.map(|s| s.to_string()),
+            api_base_url: api_base_url.map(ToString::to_string),
         },
     };
     save_persisted_config(&path, &config).await

--- a/auth/src/init.rs
+++ b/auth/src/init.rs
@@ -25,6 +25,7 @@ pub struct InitResult {
 }
 
 /// Initializes a Turnkey configuration by finding or creating an Ed25519 wallet account.
+#[allow(clippy::too_many_lines)]
 pub async fn initialize(
     org_id: &str,
     api_public_key: &str,

--- a/auth/src/ssh/agent.rs
+++ b/auth/src/ssh/agent.rs
@@ -68,10 +68,10 @@ pub async fn run(socket: PathBuf) -> anyhow::Result<()> {
 
         connections.abort_all();
         while let Some(join_result) = connections.join_next().await {
-            if let Err(error) = join_result {
-                if error.is_panic() {
-                    return Err(anyhow!("ssh-agent connection task panicked: {error}"));
-                }
+            if let Err(error) = join_result
+                && error.is_panic()
+            {
+                return Err(anyhow!("ssh-agent connection task panicked: {error}"));
             }
         }
 

--- a/auth/src/ssh/git.rs
+++ b/auth/src/ssh/git.rs
@@ -33,7 +33,7 @@ impl GitSignInvocation {
                     namespace = Some(
                         iter.next()
                             .ok_or_else(|| anyhow!("missing value after -n"))?
-                            .to_string(),
+                            .clone(),
                     );
                 }
                 "-f" => {

--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -2,7 +2,11 @@
 
 Use `tk` as Git's SSH signing program after configuring your Turnkey credentials.
 
-Ensure you have followed the [configuration section of the repository readme](../README.md#configuration).
+## Prerequisites
+
+Run `tk init` to set up your credentials and wallet. See the [quick start](../README.md#quick-start) section of the repository readme.
+
+## Setup
 
 ```bash
 git config --global gpg.format ssh

--- a/docs/ssh-agent.md
+++ b/docs/ssh-agent.md
@@ -2,21 +2,34 @@
 
 Run `tk` as a background SSH agent when you want plain `ssh` to authenticate with your Turnkey Ed25519 key.
 
-Ensure you have followed the [configuration section of the repository readme](../README.md#configuration).
+## Prerequisites
+
+Run `tk init` to set up your credentials and wallet. See the [quick start](../README.md#quick-start) section of the repository readme.
+
+## Usage
+
+Start the agent:
 
 ```bash
 tk ssh-agent start
 ```
+
+Point your shell at the agent socket and verify:
 
 ```bash
 export SSH_AUTH_SOCK=~/.config/turnkey/tk/ssh-agent.sock
 
 ssh-add -L
 ssh user@host
+```
+
+Check agent status:
+
+```bash
 tk ssh-agent status
 ```
 
-To kill the background agent:
+Stop the agent:
 
 ```bash
 tk ssh-agent stop

--- a/tk/Cargo.toml
+++ b/tk/Cargo.toml
@@ -12,6 +12,9 @@ libc = "0.2"
 tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thread", "time"] }
 turnkey_auth = { path = "../auth" }
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 assert_cmd = { workspace = true }
 base64 = { workspace = true }

--- a/tk/src/commands/agent/daemon.rs
+++ b/tk/src/commands/agent/daemon.rs
@@ -194,6 +194,7 @@ async fn wait_for_socket_removal(socket: &Path) -> anyhow::Result<()> {
     ))
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn resolve_pid_file(socket: &Path, pid_file: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     match pid_file {
         Some(pid_file) => Ok(pid_file),
@@ -330,7 +331,7 @@ fn is_process_alive(pid: u32) -> bool {
 fn send_signal(pid: u32, signal: i32) -> std::io::Result<()> {
     // SAFETY: libc::kill is an FFI syscall wrapper and does not dereference
     // Rust pointers or access Rust managed memory
-    let rc = unsafe { libc::kill(pid as i32, signal) };
+    let rc = unsafe { libc::kill(pid.cast_signed(), signal) };
     if rc == 0 {
         Ok(())
     } else {

--- a/tk/tests/agent_command.rs
+++ b/tk/tests/agent_command.rs
@@ -251,7 +251,7 @@ async fn ssh_agent_start_recovers_from_stale_pid_file() {
     let mut child =
         spawn_tk_ssh_agent_with_pid_file(&socket_path, &pid_file_path, &config_path).await;
     wait_for_socket(&socket_path, &mut child).await;
-    assert_ne!(child.pid(), 999999);
+    assert_ne!(child.pid(), 999_999);
 }
 
 #[tokio::test]
@@ -617,12 +617,11 @@ async fn wait_for_socket(socket_path: &Path, child: &mut ChildGuard) {
             return;
         }
 
-        if !child.is_running().await {
-            panic!(
-                "tk ssh-agent exited before binding socket: pid {} is not running",
-                child.pid()
-            );
-        }
+        assert!(
+            child.is_running().await,
+            "tk ssh-agent exited before binding socket: pid {} is not running",
+            child.pid()
+        );
 
         sleep(Duration::from_millis(20)).await;
     }
@@ -694,9 +693,7 @@ struct ChildGuard {
 
 impl ChildGuard {
     async fn assert_running(&mut self) {
-        if !self.is_running().await {
-            panic!("pid {} is not running", self.pid);
-        }
+        assert!(self.is_running().await, "pid {} is not running", self.pid);
     }
 
     fn pid(&self) -> u32 {
@@ -730,7 +727,7 @@ impl ChildGuard {
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
-        let _ = unsafe { libc::kill(self.pid as i32, libc::SIGTERM) };
+        let _ = unsafe { libc::kill(self.pid.cast_signed(), libc::SIGTERM) };
     }
 }
 


### PR DESCRIPTION
## Summary

- GitHub Actions CI: fmt, build (with workspace lint enforcement), test, and security audit on every push/PR to main
- Workspace lint config in Cargo.toml: `clippy::all` deny, `clippy::pedantic` warn, with targeted allows
- Pre-commit hook mirroring CI checks (activate with `git config core.hooksPath .github/hooks`)
- README rewritten with quick start guide, updated commands, config reference
- .gitignore updated with .env, .pid, .sock patterns
- Docs updated to reference `tk init` as prerequisite
- Clippy fixes across 6 files

## Test plan

- [x] `cargo build --all-targets` zero warnings
- [x] `cargo test --all` passes (pre-existing agent test failure excluded)
- [x] `cargo fmt --all -- --check` clean
- [x] Pre-commit hook is executable

**PR 3 of 3** (base: nate/pr2-init-whoami)