### PR TITLE
Add activity approve and reject commands

### DIFF
--- a/auth/src/config.rs
+++ b/auth/src/config.rs
@@ -69,9 +69,24 @@ impl Config {
             .and_then(ResolvedConfig::into_complete)
     }
 
+    /// Resolves the auth configuration for commands that only need API credentials and organization context.
+    pub async fn resolve_api_credentials() -> Result<Self> {
+        ResolvedConfig::resolve()
+            .await
+            .and_then(ResolvedConfig::into_api_credentials)
+    }
+
     /// Resolves the complete auth configuration from an explicit config path and environment map.
     pub fn resolve_from_map(path: &Path, env: &BTreeMap<String, String>) -> Result<Self> {
         ResolvedConfig::resolve_from_map(path, env).and_then(ResolvedConfig::into_complete)
+    }
+
+    /// Resolves the auth configuration for commands that only need API credentials and organization context.
+    pub fn resolve_api_credentials_from_map(
+        path: &Path,
+        env: &BTreeMap<String, String>,
+    ) -> Result<Self> {
+        ResolvedConfig::resolve_from_map(path, env).and_then(ResolvedConfig::into_api_credentials)
     }
 }
 
@@ -183,6 +198,16 @@ impl ResolvedConfig {
             api_public_key: required_value("turnkey.apiPublicKey", self.api_public_key)?,
             api_private_key: required_value("turnkey.apiPrivateKey", self.api_private_key)?,
             private_key_id: required_value("turnkey.privateKeyId", self.private_key_id)?,
+            api_base_url: self.api_base_url,
+        })
+    }
+
+    fn into_api_credentials(self) -> Result<Config> {
+        Ok(Config {
+            organization_id: required_value("turnkey.organizationId", self.organization_id)?,
+            api_public_key: required_value("turnkey.apiPublicKey", self.api_public_key)?,
+            api_private_key: required_value("turnkey.apiPrivateKey", self.api_private_key)?,
+            private_key_id: self.private_key_id.unwrap_or_default(),
             api_base_url: self.api_base_url,
         })
     }

--- a/auth/src/config.rs
+++ b/auth/src/config.rs
@@ -69,24 +69,9 @@ impl Config {
             .and_then(ResolvedConfig::into_complete)
     }
 
-    /// Resolves the auth configuration for commands that only need API credentials and organization context.
-    pub async fn resolve_api_credentials() -> Result<Self> {
-        ResolvedConfig::resolve()
-            .await
-            .and_then(ResolvedConfig::into_api_credentials)
-    }
-
     /// Resolves the complete auth configuration from an explicit config path and environment map.
     pub fn resolve_from_map(path: &Path, env: &BTreeMap<String, String>) -> Result<Self> {
         ResolvedConfig::resolve_from_map(path, env).and_then(ResolvedConfig::into_complete)
-    }
-
-    /// Resolves the auth configuration for commands that only need API credentials and organization context.
-    pub fn resolve_api_credentials_from_map(
-        path: &Path,
-        env: &BTreeMap<String, String>,
-    ) -> Result<Self> {
-        ResolvedConfig::resolve_from_map(path, env).and_then(ResolvedConfig::into_api_credentials)
     }
 }
 
@@ -193,16 +178,6 @@ impl ResolvedConfig {
     }
 
     fn into_complete(self) -> Result<Config> {
-        Ok(Config {
-            organization_id: required_value("turnkey.organizationId", self.organization_id)?,
-            api_public_key: required_value("turnkey.apiPublicKey", self.api_public_key)?,
-            api_private_key: required_value("turnkey.apiPrivateKey", self.api_private_key)?,
-            private_key_id: required_value("turnkey.privateKeyId", self.private_key_id)?,
-            api_base_url: self.api_base_url,
-        })
-    }
-
-    fn into_api_credentials(self) -> Result<Config> {
         Ok(Config {
             organization_id: required_value("turnkey.organizationId", self.organization_id)?,
             api_public_key: required_value("turnkey.apiPublicKey", self.api_public_key)?,

--- a/auth/src/turnkey.rs
+++ b/auth/src/turnkey.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result, anyhow};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use turnkey_client::generated::immutable::activity::v1 as immutable_activity;
 use turnkey_client::generated::immutable::common::v1::HashFunction;
 use turnkey_client::generated::immutable::common::v1::PayloadEncoding;
-use turnkey_client::generated::{GetPrivateKeyRequest, SignRawPayloadIntentV2};
+use turnkey_client::generated::{GetActivityRequest, GetPrivateKeyRequest, SignRawPayloadIntentV2};
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
 
 use crate::config::Config;
@@ -57,8 +58,46 @@ impl TurnkeySigner {
         self.sign_raw_ed25519_payload(payload).await
     }
 
+    /// Approves a pending activity by its fingerprint.
+    pub async fn approve_activity(&self, fingerprint: &str) -> Result<()> {
+        self.client
+            .approve_activity(
+                self.config.organization_id.clone(),
+                self.client.current_timestamp(),
+                immutable_activity::ApproveActivityIntent {
+                    fingerprint: fingerprint.to_string(),
+                },
+            )
+            .await
+            .map_err(map_turnkey_error)?;
+        Ok(())
+    }
+
+    /// Rejects a pending activity by its fingerprint.
+    pub async fn reject_activity(&self, fingerprint: &str) -> Result<()> {
+        match self
+            .client
+            .reject_activity(
+                self.config.organization_id.clone(),
+                self.client.current_timestamp(),
+                immutable_activity::RejectActivityIntent {
+                    fingerprint: fingerprint.to_string(),
+                },
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(TurnkeyClientError::UnexpectedActivityStatus(status))
+                if status == "ACTIVITY_STATUS_REJECTED" =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(map_turnkey_error(e)),
+        }
+    }
+
     async fn sign_raw_ed25519_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        let response = self
+        match self
             .client
             .sign_raw_payload(
                 self.config.organization_id.clone(),
@@ -71,9 +110,45 @@ impl TurnkeySigner {
                 },
             )
             .await
+        {
+            Ok(response) => {
+                decode_signature_parts(&response.result.r, &response.result.s, &response.result.v)
+            }
+            Err(TurnkeyClientError::ActivityRequiresApproval(activity_id)) => {
+                Err(self.consensus_required_error(&activity_id).await)
+            }
+            Err(other) => Err(map_turnkey_error(other)),
+        }
+    }
+
+    async fn consensus_required_error(&self, activity_id: &str) -> anyhow::Error {
+        match self.get_activity_fingerprint(activity_id).await {
+            Ok(fingerprint) => {
+                anyhow!("signing requires consensus approval (fingerprint: {fingerprint})")
+            }
+            Err(_) => anyhow!("signing requires consensus approval (activity id: {activity_id})"),
+        }
+    }
+
+    async fn get_activity_fingerprint(&self, activity_id: &str) -> Result<String> {
+        let response = self
+            .client
+            .get_activity(GetActivityRequest {
+                organization_id: self.config.organization_id.clone(),
+                activity_id: activity_id.to_string(),
+            })
+            .await
             .map_err(map_turnkey_error)?;
 
-        decode_signature_parts(&response.result.r, &response.result.s, &response.result.v)
+        let activity = response
+            .activity
+            .ok_or_else(|| anyhow!("Turnkey did not return an activity object"))?;
+
+        if activity.fingerprint.is_empty() {
+            return Err(anyhow!("Turnkey activity fingerprint was empty"));
+        }
+
+        Ok(activity.fingerprint)
     }
 }
 
@@ -121,6 +196,18 @@ mod tests {
     use wiremock::matchers::{header_exists, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    fn test_signer(server: &MockServer) -> TurnkeySigner {
+        let api_key = TurnkeyP256ApiKey::generate();
+        TurnkeySigner::new(Config {
+            organization_id: "org-id".to_string(),
+            api_public_key: hex::encode(api_key.compressed_public_key()),
+            api_private_key: hex::encode(api_key.private_key()),
+            private_key_id: "pk-id".to_string(),
+            api_base_url: server.uri(),
+        })
+        .expect("signer should build")
+    }
+
     #[test]
     fn decode_public_key_rejects_base64_input() {
         let error = decode_public_key("ZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmY=")
@@ -142,7 +229,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decode_signature_parts_signs_raw_ssh_auth_payload() {
+    async fn sign_returns_signature_on_immediate_success() {
         let server = MockServer::start().await;
         let payload = b"ssh-agent-challenge";
         let signature = [0x55; 64];
@@ -173,20 +260,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let api_key = TurnkeyP256ApiKey::generate();
-        let signer = TurnkeySigner::new(Config {
-            organization_id: "org-id".to_string(),
-            api_public_key: hex::encode(api_key.compressed_public_key()),
-            api_private_key: hex::encode(api_key.private_key()),
-            private_key_id: "pk-id".to_string(),
-            api_base_url: server.uri(),
-        })
-        .expect("signer should build");
-
+        let signer = test_signer(&server);
         let result = signer
             .sign_ssh_auth_payload(payload)
             .await
             .expect("ssh auth payload should sign");
+
+        assert_eq!(result, signature.to_vec());
 
         let requests = server
             .received_requests()
@@ -208,6 +288,199 @@ mod tests {
             body["parameters"]["hashFunction"],
             "HASH_FUNCTION_NOT_APPLICABLE"
         );
-        assert_eq!(result, signature.to_vec());
+    }
+
+    #[tokio::test]
+    async fn sign_returns_error_when_consensus_needed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_raw_payload"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "consensus-activity-id",
+                    "organizationId": "org-id",
+                    "fingerprint": "consensus-fingerprint",
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/get_activity"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "consensus-activity-id",
+                    "organizationId": "org-id",
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                    "intent": null,
+                    "result": null,
+                    "votes": [],
+                    "appProofs": [],
+                    "fingerprint": "consensus-fingerprint",
+                    "canApprove": false,
+                    "canReject": true,
+                    "createdAt": null,
+                    "updatedAt": null,
+                    "failure": null
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = test_signer(&server);
+        let error = signer
+            .sign_ed25519(b"test-payload")
+            .await
+            .expect_err("sign should fail when consensus needed");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("consensus") && message.contains("consensus-fingerprint"),
+            "error should mention consensus and contain the activity fingerprint: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_falls_back_to_activity_id_when_fingerprint_lookup_fails() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/sign_raw_payload"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "consensus-activity-id",
+                    "organizationId": "org-id",
+                    "fingerprint": "consensus-fingerprint",
+                    "status": "ACTIVITY_STATUS_CONSENSUS_NEEDED",
+                    "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/query/get_activity"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let signer = test_signer(&server);
+        let error = signer
+            .sign_ed25519(b"test-payload")
+            .await
+            .expect_err("sign should fail when consensus needed");
+
+        assert_eq!(
+            error.to_string(),
+            "signing requires consensus approval (activity id: consensus-activity-id)"
+        );
+    }
+
+    #[tokio::test]
+    async fn approve_activity_sends_fingerprint() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/approve_activity"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "approve-act-id",
+                    "organizationId": "org-id",
+                    "fingerprint": "approve-fp",
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "type": "ACTIVITY_TYPE_APPROVE_ACTIVITY"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = test_signer(&server);
+        signer
+            .approve_activity("test-fingerprint")
+            .await
+            .expect("approve should succeed");
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("request recording should be enabled");
+        assert_eq!(requests.len(), 1);
+        let body: serde_json::Value = requests[0]
+            .body_json()
+            .expect("request body should be valid JSON");
+        assert_eq!(body["type"], "ACTIVITY_TYPE_APPROVE_ACTIVITY");
+        assert_eq!(body["parameters"]["fingerprint"], "test-fingerprint");
+    }
+
+    #[tokio::test]
+    async fn reject_activity_sends_fingerprint() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/reject_activity"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "reject-act-id",
+                    "organizationId": "org-id",
+                    "fingerprint": "reject-fp",
+                    "status": "ACTIVITY_STATUS_COMPLETED",
+                    "type": "ACTIVITY_TYPE_REJECT_ACTIVITY"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = test_signer(&server);
+        signer
+            .reject_activity("test-fingerprint")
+            .await
+            .expect("reject should succeed");
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("request recording should be enabled");
+        assert_eq!(requests.len(), 1);
+        let body: serde_json::Value = requests[0]
+            .body_json()
+            .expect("request body should be valid JSON");
+        assert_eq!(body["type"], "ACTIVITY_TYPE_REJECT_ACTIVITY");
+        assert_eq!(body["parameters"]["fingerprint"], "test-fingerprint");
+    }
+
+    #[tokio::test]
+    async fn reject_activity_handles_rejected_status() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/public/v1/submit/reject_activity"))
+            .and(header_exists("X-Stamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "activity": {
+                    "id": "reject-act-id",
+                    "organizationId": "org-id",
+                    "fingerprint": "reject-fp",
+                    "status": "ACTIVITY_STATUS_REJECTED",
+                    "type": "ACTIVITY_TYPE_REJECT_ACTIVITY"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let signer = test_signer(&server);
+        signer
+            .reject_activity("test-fingerprint")
+            .await
+            .expect("reject should succeed even when status is REJECTED");
     }
 }

--- a/auth/src/turnkey.rs
+++ b/auth/src/turnkey.rs
@@ -3,7 +3,9 @@ use turnkey_api_key_stamper::TurnkeyP256ApiKey;
 use turnkey_client::generated::immutable::activity::v1 as immutable_activity;
 use turnkey_client::generated::immutable::common::v1::HashFunction;
 use turnkey_client::generated::immutable::common::v1::PayloadEncoding;
-use turnkey_client::generated::{GetActivityRequest, GetPrivateKeyRequest, SignRawPayloadIntentV2};
+use turnkey_client::generated::{
+    ActivityStatus, GetActivityRequest, GetPrivateKeyRequest, SignRawPayloadIntentV2,
+};
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
 
 use crate::config::Config;
@@ -32,11 +34,12 @@ impl TurnkeySigner {
 
     /// Fetches the configured Ed25519 public key bytes from Turnkey.
     pub async fn get_public_key(&self) -> Result<Vec<u8>> {
+        let private_key_id = self.required_private_key_id()?;
         let response = self
             .client
             .get_private_key(GetPrivateKeyRequest {
                 organization_id: self.config.organization_id.clone(),
-                private_key_id: self.config.private_key_id.clone(),
+                private_key_id: private_key_id.to_string(),
             })
             .await
             .map_err(map_turnkey_error)?;
@@ -88,7 +91,7 @@ impl TurnkeySigner {
         {
             Ok(_) => Ok(()),
             Err(TurnkeyClientError::UnexpectedActivityStatus(status))
-                if status == "ACTIVITY_STATUS_REJECTED" =>
+                if status == ActivityStatus::Rejected.as_str_name() =>
             {
                 Ok(())
             }
@@ -97,13 +100,14 @@ impl TurnkeySigner {
     }
 
     async fn sign_raw_ed25519_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
+        let private_key_id = self.required_private_key_id()?;
         match self
             .client
             .sign_raw_payload(
                 self.config.organization_id.clone(),
                 self.client.current_timestamp(),
                 SignRawPayloadIntentV2 {
-                    sign_with: self.config.private_key_id.clone(),
+                    sign_with: private_key_id.to_string(),
                     payload: hex::encode(payload),
                     encoding: PayloadEncoding::Hexadecimal,
                     hash_function: HashFunction::NotApplicable,
@@ -121,11 +125,12 @@ impl TurnkeySigner {
         }
     }
 
+    /// Builds a consensus-needed error and enriches it with the activity fingerprint when available.
     async fn consensus_required_error(&self, activity_id: &str) -> anyhow::Error {
         match self.get_activity_fingerprint(activity_id).await {
-            Ok(fingerprint) => {
-                anyhow!("signing requires consensus approval (fingerprint: {fingerprint})")
-            }
+            Ok(fingerprint) => anyhow!(
+                "signing requires consensus approval (fingerprint: {fingerprint}, activity id: {activity_id})"
+            ),
             Err(_) => anyhow!("signing requires consensus approval (activity id: {activity_id})"),
         }
     }
@@ -149,6 +154,14 @@ impl TurnkeySigner {
         }
 
         Ok(activity.fingerprint)
+    }
+
+    fn required_private_key_id(&self) -> Result<&str> {
+        if self.config.private_key_id.is_empty() {
+            return Err(anyhow!("missing required config value: turnkey.privateKeyId"));
+        }
+
+        Ok(&self.config.private_key_id)
     }
 }
 
@@ -341,8 +354,10 @@ mod tests {
 
         let message = error.to_string();
         assert!(
-            message.contains("consensus") && message.contains("consensus-fingerprint"),
-            "error should mention consensus and contain the activity fingerprint: {message}"
+            message.contains("consensus")
+                && message.contains("consensus-fingerprint")
+                && message.contains("consensus-activity-id"),
+            "error should mention consensus and contain both activity fingerprint and id: {message}"
         );
     }
 
@@ -381,6 +396,30 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "signing requires consensus approval (activity id: consensus-activity-id)"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_requires_private_key_id() {
+        let server = MockServer::start().await;
+        let api_key = TurnkeyP256ApiKey::generate();
+        let signer = TurnkeySigner::new(Config {
+            organization_id: "org-id".to_string(),
+            api_public_key: hex::encode(api_key.compressed_public_key()),
+            api_private_key: hex::encode(api_key.private_key()),
+            private_key_id: String::new(),
+            api_base_url: server.uri(),
+        })
+        .expect("signer should build");
+
+        let error = signer
+            .sign_ed25519(b"test-payload")
+            .await
+            .expect_err("sign should require a private key id");
+
+        assert_eq!(
+            error.to_string(),
+            "missing required config value: turnkey.privateKeyId"
         );
     }
 

--- a/auth/tests/config_resolution.rs
+++ b/auth/tests/config_resolution.rs
@@ -55,3 +55,27 @@ privateKeyId = "file-key"
     assert_eq!(config.private_key_id, "env-key");
     assert_eq!(config.api_base_url, "https://api.turnkey.com");
 }
+
+#[test]
+fn api_credentials_resolution_does_not_require_private_key_id() {
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("tk.toml");
+    fs::write(
+        &config_path,
+        r#"[turnkey]
+organizationId = "file-org"
+apiPublicKey = "file-pub"
+apiPrivateKey = "file-priv"
+    "#,
+    )
+    .unwrap();
+
+    let env = BTreeMap::new();
+    let config = Config::resolve_api_credentials_from_map(&config_path, &env).unwrap();
+
+    assert_eq!(config.organization_id, "file-org");
+    assert_eq!(config.api_public_key, "file-pub");
+    assert_eq!(config.api_private_key, "file-priv");
+    assert_eq!(config.private_key_id, "");
+    assert_eq!(config.api_base_url, "https://api.turnkey.com");
+}

--- a/auth/tests/config_resolution.rs
+++ b/auth/tests/config_resolution.rs
@@ -57,7 +57,7 @@ privateKeyId = "file-key"
 }
 
 #[test]
-fn api_credentials_resolution_does_not_require_private_key_id() {
+fn config_resolution_does_not_require_private_key_id() {
     let temp = tempdir().unwrap();
     let config_path = temp.path().join("tk.toml");
     fs::write(
@@ -71,7 +71,7 @@ apiPrivateKey = "file-priv"
     .unwrap();
 
     let env = BTreeMap::new();
-    let config = Config::resolve_api_credentials_from_map(&config_path, &env).unwrap();
+    let config = Config::resolve_from_map(&config_path, &env).unwrap();
 
     assert_eq!(config.organization_id, "file-org");
     assert_eq!(config.api_public_key, "file-pub");

--- a/tk/src/cli.rs
+++ b/tk/src/cli.rs
@@ -20,6 +20,7 @@ impl Cli {
         let args = Self::parse();
 
         match args.command {
+            Commands::Activity(args) => commands::activity::run(args).await,
             Commands::Config(args) => commands::config::run(args).await,
             Commands::Ssh(args) => commands::ssh::run(args).await,
         }
@@ -28,6 +29,8 @@ impl Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Activity approval and rejection commands.
+    Activity(commands::activity::Args),
     /// Inspect and update persistent auth configuration.
     Config(commands::config::Args),
     /// SSH related commands.

--- a/tk/src/commands/activity.rs
+++ b/tk/src/commands/activity.rs
@@ -39,7 +39,7 @@ pub struct RejectArgs {
 }
 
 async fn approve(args: ApproveArgs) -> anyhow::Result<()> {
-    let config = turnkey_auth::config::Config::resolve_api_credentials().await?;
+    let config = turnkey_auth::config::Config::resolve().await?;
     let signer = turnkey_auth::turnkey::TurnkeySigner::new(config)?;
     signer.approve_activity(&args.fingerprint).await?;
     println!("Activity approved.");
@@ -47,7 +47,7 @@ async fn approve(args: ApproveArgs) -> anyhow::Result<()> {
 }
 
 async fn reject(args: RejectArgs) -> anyhow::Result<()> {
-    let config = turnkey_auth::config::Config::resolve_api_credentials().await?;
+    let config = turnkey_auth::config::Config::resolve().await?;
     let signer = turnkey_auth::turnkey::TurnkeySigner::new(config)?;
     signer.reject_activity(&args.fingerprint).await?;
     println!("Activity rejected.");

--- a/tk/src/commands/activity.rs
+++ b/tk/src/commands/activity.rs
@@ -1,0 +1,55 @@
+use clap::{Args as ClapArgs, Subcommand};
+
+/// Top-level arguments for `tk activity`.
+#[derive(Debug, ClapArgs)]
+#[command(about = "Activity approval and rejection commands.", long_about = None)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+/// Runs the `tk activity` subcommand tree.
+pub async fn run(args: Args) -> anyhow::Result<()> {
+    match args.command {
+        Command::Approve(args) => approve(args).await,
+        Command::Reject(args) => reject(args).await,
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Approve a pending activity that requires consensus.
+    Approve(ApproveArgs),
+    /// Reject a pending activity that requires consensus.
+    Reject(RejectArgs),
+}
+
+/// Arguments for `tk activity approve`.
+#[derive(Debug, ClapArgs)]
+pub struct ApproveArgs {
+    /// The fingerprint of the activity to approve.
+    pub fingerprint: String,
+}
+
+/// Arguments for `tk activity reject`.
+#[derive(Debug, ClapArgs)]
+pub struct RejectArgs {
+    /// The fingerprint of the activity to reject.
+    pub fingerprint: String,
+}
+
+async fn approve(args: ApproveArgs) -> anyhow::Result<()> {
+    let config = turnkey_auth::config::Config::resolve_api_credentials().await?;
+    let signer = turnkey_auth::turnkey::TurnkeySigner::new(config)?;
+    signer.approve_activity(&args.fingerprint).await?;
+    println!("Activity approved.");
+    Ok(())
+}
+
+async fn reject(args: RejectArgs) -> anyhow::Result<()> {
+    let config = turnkey_auth::config::Config::resolve_api_credentials().await?;
+    let signer = turnkey_auth::turnkey::TurnkeySigner::new(config)?;
+    signer.reject_activity(&args.fingerprint).await?;
+    println!("Activity rejected.");
+    Ok(())
+}

--- a/tk/src/commands/mod.rs
+++ b/tk/src/commands/mod.rs
@@ -1,3 +1,5 @@
+/// Activity approval and rejection command namespace.
+pub mod activity;
 /// Background SSH agent lifecycle commands.
 pub mod agent;
 /// Persistent configuration inspection and mutation commands.

--- a/tk/tests/activity_command.rs
+++ b/tk/tests/activity_command.rs
@@ -1,0 +1,97 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use turnkey_api_key_stamper::TurnkeyP256ApiKey;
+use wiremock::matchers::{header_exists, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[test]
+fn activity_help_lists_subcommands() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("activity").arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("approve"))
+        .stdout(predicate::str::contains("reject"))
+        .stdout(predicate::str::contains("tk activity <COMMAND>"));
+}
+
+#[tokio::test]
+async fn activity_approve_does_not_require_private_key_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/approve_activity"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "approve-act-id",
+                "organizationId": "org-id",
+                "fingerprint": "approve-fp",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_APPROVE_ACTIVITY"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let api_key = TurnkeyP256ApiKey::generate();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("activity")
+        .arg("approve")
+        .arg("test-fingerprint")
+        .env("TURNKEY_ORGANIZATION_ID", "org-id")
+        .env(
+            "TURNKEY_API_PUBLIC_KEY",
+            hex::encode(api_key.compressed_public_key()),
+        )
+        .env(
+            "TURNKEY_API_PRIVATE_KEY",
+            hex::encode(api_key.private_key()),
+        )
+        .env_remove("TURNKEY_PRIVATE_KEY_ID")
+        .env("TURNKEY_API_BASE_URL", server.uri());
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Activity approved."));
+}
+
+#[tokio::test]
+async fn activity_reject_does_not_require_private_key_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/public/v1/submit/reject_activity"))
+        .and(header_exists("X-Stamp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "activity": {
+                "id": "reject-act-id",
+                "organizationId": "org-id",
+                "fingerprint": "reject-fp",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_REJECT_ACTIVITY"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let api_key = TurnkeyP256ApiKey::generate();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tk"));
+    cmd.arg("activity")
+        .arg("reject")
+        .arg("test-fingerprint")
+        .env("TURNKEY_ORGANIZATION_ID", "org-id")
+        .env(
+            "TURNKEY_API_PUBLIC_KEY",
+            hex::encode(api_key.compressed_public_key()),
+        )
+        .env(
+            "TURNKEY_API_PRIVATE_KEY",
+            hex::encode(api_key.private_key()),
+        )
+        .env_remove("TURNKEY_PRIVATE_KEY_ID")
+        .env("TURNKEY_API_BASE_URL", server.uri());
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Activity rejected."));
+}

--- a/tk/tests/cli.rs
+++ b/tk/tests/cli.rs
@@ -9,6 +9,7 @@ fn cli_help_lists_commands() {
 
     cmd.assert()
         .success()
+        .stdout(predicate::str::contains("activity"))
         .stdout(predicate::str::contains("config"))
         .stdout(predicate::str::contains("ssh"))
         .stdout(predicate::str::contains("TURNKEY_ORGANIZATION_ID"))
@@ -18,7 +19,7 @@ fn cli_help_lists_commands() {
         .stdout(predicate::str::contains("TURNKEY_API_BASE_URL"))
         .stdout(predicate::str::contains("TURNKEY_TK_CONFIG_PATH"))
         .stdout(predicate::str::contains("~/.config/turnkey/tk/tk.toml"))
-        .stdout(predicate::str::contains("ssh     SSH-related commands"))
+        .stdout(predicate::str::contains("ssh       SSH related commands"))
         .stdout(predicate::str::contains("tk ssh agent start"))
         .stdout(predicate::str::contains(
             "export SSH_AUTH_SOCK=~/.config/turnkey/tk/ssh-agent.sock",


### PR DESCRIPTION
## Summary

Add consensus activity approval helpers to the auth layer and expose them through `tk activity approve` and `tk activity reject`.

## What changed

- `TurnkeySigner` now maps `ACTIVITY_STATUS_CONSENSUS_NEEDED` into a clear signing error that includes the activity ID
- Added `approve_activity(fingerprint)` and `reject_activity(fingerprint)` to `TurnkeySigner`
- `reject_activity` treats `ACTIVITY_STATUS_REJECTED` as a successful terminal state
- Added the `tk activity approve <fingerprint>` and `tk activity reject <fingerprint>` CLI surface
- Extended CLI help coverage for the new nested command namespace

## Tested

- `cargo test -p tk --test cli`
- `cargo test -p turnkey_auth approve_activity_sends_fingerprint`
- `cargo test -p turnkey_auth reject_activity_sends_fingerprint`
- `cargo test -p turnkey_auth reject_activity_handles_rejected_status`
- `cargo test -p turnkey_auth sign_returns_error_when_consensus_needed`