### PR TITLE
Simplify TurnkeySigner: collapse signing methods, move activity logic to CLI

### DIFF
--- a/auth/src/git_sign.rs
+++ b/auth/src/git_sign.rs
@@ -18,7 +18,7 @@ pub async fn run_git_sign(ssh_keygen_args: &[String]) -> anyhow::Result<()> {
         ));
     }
     let signed_data = ssh::build_signed_data("git", &payload);
-    let signature = signer.sign_ed25519(&signed_data).await?;
+    let signature = signer.sign_raw_payload(&signed_data).await?;
     let armored = ssh::encode_armored_signature(
         &parsed_public_key.public_key_blob,
         "git",

--- a/auth/src/ssh/agent.rs
+++ b/auth/src/ssh/agent.rs
@@ -111,7 +111,7 @@ async fn handle_connection(
             Some(protocol::SSH_AGENTC_SIGN_REQUEST) => {
                 match protocol::parse_sign_request_frame(&frame) {
                     Ok(request) if request.public_key_blob == *configured_public_key_blob => {
-                        match signer.sign_ssh_auth_payload(&request.data).await {
+                        match signer.sign_raw_payload(&request.data).await {
                             Ok(signature) => protocol::encode_sign_response(&signature)
                                 .unwrap_or_else(|_| {
                                     protocol::encode_agent_frame(protocol::SSH_AGENT_FAILURE, &[])

--- a/auth/src/turnkey.rs
+++ b/auth/src/turnkey.rs
@@ -1,11 +1,8 @@
 use anyhow::{Context, Result, anyhow};
 use turnkey_api_key_stamper::TurnkeyP256ApiKey;
-use turnkey_client::generated::immutable::activity::v1 as immutable_activity;
 use turnkey_client::generated::immutable::common::v1::HashFunction;
 use turnkey_client::generated::immutable::common::v1::PayloadEncoding;
-use turnkey_client::generated::{
-    ActivityStatus, GetActivityRequest, GetPrivateKeyRequest, SignRawPayloadIntentV2,
-};
+use turnkey_client::generated::{GetActivityRequest, GetPrivateKeyRequest, SignRawPayloadIntentV2};
 use turnkey_client::{TurnkeyClient, TurnkeyClientError};
 
 use crate::config::Config;
@@ -62,54 +59,7 @@ impl TurnkeySigner {
     }
 
     /// Signs a raw Ed25519 payload through Turnkey and returns the 64-byte signature.
-    pub async fn sign_ed25519(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.sign_raw_ed25519_payload(payload).await
-    }
-
-    /// Signs a raw SSH authentication payload through Turnkey and returns the 64-byte signature.
-    pub async fn sign_ssh_auth_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.sign_raw_ed25519_payload(payload).await
-    }
-
-    /// Approves a pending activity by its fingerprint.
-    pub async fn approve_activity(&self, fingerprint: &str) -> Result<()> {
-        self.client
-            .approve_activity(
-                self.config.organization_id.clone(),
-                self.client.current_timestamp(),
-                immutable_activity::ApproveActivityIntent {
-                    fingerprint: fingerprint.to_string(),
-                },
-            )
-            .await
-            .map_err(map_turnkey_error)?;
-        Ok(())
-    }
-
-    /// Rejects a pending activity by its fingerprint.
-    pub async fn reject_activity(&self, fingerprint: &str) -> Result<()> {
-        match self
-            .client
-            .reject_activity(
-                self.config.organization_id.clone(),
-                self.client.current_timestamp(),
-                immutable_activity::RejectActivityIntent {
-                    fingerprint: fingerprint.to_string(),
-                },
-            )
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(TurnkeyClientError::UnexpectedActivityStatus(status))
-                if status == ActivityStatus::Rejected.as_str_name() =>
-            {
-                Ok(())
-            }
-            Err(e) => Err(map_turnkey_error(e)),
-        }
-    }
-
-    async fn sign_raw_ed25519_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
+    pub async fn sign_raw_payload(&self, payload: &[u8]) -> Result<Vec<u8>> {
         let private_key_id = self.required_private_key_id()?;
         match self
             .client
@@ -285,9 +235,9 @@ mod tests {
 
         let signer = test_signer(&server);
         let result = signer
-            .sign_ssh_auth_payload(payload)
+            .sign_raw_payload(payload)
             .await
-            .expect("ssh auth payload should sign");
+            .expect("raw payload should sign");
 
         assert_eq!(result, signature.to_vec());
 
@@ -358,7 +308,7 @@ mod tests {
 
         let signer = test_signer(&server);
         let error = signer
-            .sign_ed25519(b"test-payload")
+            .sign_raw_payload(b"test-payload")
             .await
             .expect_err("sign should fail when consensus needed");
 
@@ -399,7 +349,7 @@ mod tests {
 
         let signer = test_signer(&server);
         let error = signer
-            .sign_ed25519(b"test-payload")
+            .sign_raw_payload(b"test-payload")
             .await
             .expect_err("sign should fail when consensus needed");
 
@@ -423,7 +373,7 @@ mod tests {
         .expect("signer should build");
 
         let error = signer
-            .sign_ed25519(b"test-payload")
+            .sign_raw_payload(b"test-payload")
             .await
             .expect_err("sign should require a private key id");
 
@@ -433,103 +383,4 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn approve_activity_sends_fingerprint() {
-        let server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/public/v1/submit/approve_activity"))
-            .and(header_exists("X-Stamp"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "activity": {
-                    "id": "approve-act-id",
-                    "organizationId": "org-id",
-                    "fingerprint": "approve-fp",
-                    "status": "ACTIVITY_STATUS_COMPLETED",
-                    "type": "ACTIVITY_TYPE_APPROVE_ACTIVITY"
-                }
-            })))
-            .mount(&server)
-            .await;
-
-        let signer = test_signer(&server);
-        signer
-            .approve_activity("test-fingerprint")
-            .await
-            .expect("approve should succeed");
-
-        let requests = server
-            .received_requests()
-            .await
-            .expect("request recording should be enabled");
-        assert_eq!(requests.len(), 1);
-        let body: serde_json::Value = requests[0]
-            .body_json()
-            .expect("request body should be valid JSON");
-        assert_eq!(body["type"], "ACTIVITY_TYPE_APPROVE_ACTIVITY");
-        assert_eq!(body["parameters"]["fingerprint"], "test-fingerprint");
-    }
-
-    #[tokio::test]
-    async fn reject_activity_sends_fingerprint() {
-        let server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/public/v1/submit/reject_activity"))
-            .and(header_exists("X-Stamp"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "activity": {
-                    "id": "reject-act-id",
-                    "organizationId": "org-id",
-                    "fingerprint": "reject-fp",
-                    "status": "ACTIVITY_STATUS_COMPLETED",
-                    "type": "ACTIVITY_TYPE_REJECT_ACTIVITY"
-                }
-            })))
-            .mount(&server)
-            .await;
-
-        let signer = test_signer(&server);
-        signer
-            .reject_activity("test-fingerprint")
-            .await
-            .expect("reject should succeed");
-
-        let requests = server
-            .received_requests()
-            .await
-            .expect("request recording should be enabled");
-        assert_eq!(requests.len(), 1);
-        let body: serde_json::Value = requests[0]
-            .body_json()
-            .expect("request body should be valid JSON");
-        assert_eq!(body["type"], "ACTIVITY_TYPE_REJECT_ACTIVITY");
-        assert_eq!(body["parameters"]["fingerprint"], "test-fingerprint");
-    }
-
-    #[tokio::test]
-    async fn reject_activity_handles_rejected_status() {
-        let server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/public/v1/submit/reject_activity"))
-            .and(header_exists("X-Stamp"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "activity": {
-                    "id": "reject-act-id",
-                    "organizationId": "org-id",
-                    "fingerprint": "reject-fp",
-                    "status": "ACTIVITY_STATUS_REJECTED",
-                    "type": "ACTIVITY_TYPE_REJECT_ACTIVITY"
-                }
-            })))
-            .mount(&server)
-            .await;
-
-        let signer = test_signer(&server);
-        signer
-            .reject_activity("test-fingerprint")
-            .await
-            .expect("reject should succeed even when status is REJECTED");
-    }
 }

--- a/tk/src/commands/activity.rs
+++ b/tk/src/commands/activity.rs
@@ -1,4 +1,6 @@
+use anyhow::{Result, anyhow};
 use clap::{Args as ClapArgs, Subcommand};
+use turnkey_client::generated::immutable::activity::v1 as activity;
 
 /// Top-level arguments for `tk activity`.
 #[derive(Debug, ClapArgs)]
@@ -9,7 +11,7 @@ pub struct Args {
 }
 
 /// Runs the `tk activity` subcommand tree.
-pub async fn run(args: Args) -> anyhow::Result<()> {
+pub async fn run(args: Args) -> Result<()> {
     match args.command {
         Command::Approve(args) => approve(args).await,
         Command::Reject(args) => reject(args).await,
@@ -38,18 +40,44 @@ pub struct RejectArgs {
     pub fingerprint: String,
 }
 
-async fn approve(args: ApproveArgs) -> anyhow::Result<()> {
+async fn approve(args: ApproveArgs) -> Result<()> {
     let config = turnkey_auth::config::Config::resolve().await?;
     let signer = turnkey_auth::turnkey::TurnkeySigner::new(config)?;
-    signer.approve_activity(&args.fingerprint).await?;
+    let client = signer.client();
+    let org_id = signer.organization_id().to_string();
+
+    client
+        .approve_activity(
+            org_id,
+            client.current_timestamp(),
+            activity::ApproveActivityIntent {
+                fingerprint: args.fingerprint,
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("failed to approve activity: {e}"))?;
+
     println!("Activity approved.");
     Ok(())
 }
 
-async fn reject(args: RejectArgs) -> anyhow::Result<()> {
+async fn reject(args: RejectArgs) -> Result<()> {
     let config = turnkey_auth::config::Config::resolve().await?;
     let signer = turnkey_auth::turnkey::TurnkeySigner::new(config)?;
-    signer.reject_activity(&args.fingerprint).await?;
+    let client = signer.client();
+    let org_id = signer.organization_id().to_string();
+
+    client
+        .reject_activity(
+            org_id,
+            client.current_timestamp(),
+            activity::RejectActivityIntent {
+                fingerprint: args.fingerprint,
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("failed to reject activity: {e}"))?;
+
     println!("Activity rejected.");
     Ok(())
 }

--- a/tk/src/commands/activity.rs
+++ b/tk/src/commands/activity.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result, anyhow};
 use clap::{Args as ClapArgs, Subcommand};
 use turnkey_client::generated::immutable::activity::v1 as activity;
+use turnkey_client::generated::ActivityStatus;
+use turnkey_client::TurnkeyClientError;
 
 /// Top-level arguments for `tk activity`.
 #[derive(Debug, ClapArgs)]
@@ -67,7 +69,7 @@ async fn reject(args: RejectArgs) -> Result<()> {
     let client = signer.client();
     let org_id = signer.organization_id().to_string();
 
-    client
+    match client
         .reject_activity(
             org_id,
             client.current_timestamp(),
@@ -76,7 +78,13 @@ async fn reject(args: RejectArgs) -> Result<()> {
             },
         )
         .await
-        .map_err(|e| anyhow!("failed to reject activity: {e}"))?;
+    {
+        Ok(_) => {}
+        // Treat already-rejected as success for retry safety.
+        Err(TurnkeyClientError::UnexpectedActivityStatus(status))
+            if status == ActivityStatus::Rejected.as_str_name() => {}
+        Err(e) => return Err(anyhow!("failed to reject activity: {e}")),
+    }
 
     println!("Activity rejected.");
     Ok(())


### PR DESCRIPTION
## Summary

- Collapse `sign_ed25519` and `sign_ssh_auth_payload` into a single `sign_raw_payload` method (they were identical wrappers)
- Remove `approve_activity` and `reject_activity` from `TurnkeySigner`, move API calls to the CLI activity command using `client()` directly
- Remove the silent swallow of already-rejected status from reject, letting the CLI handle errors transparently
- The CLI should be a thin pass-through to the API, not a place for custom design choices

## Test plan

- [ ] All workspace tests pass (43 tests)
- [ ] E2e consensus demo still works (setup, sign, approve, teardown)